### PR TITLE
Validators απαντήσεων χωρίς παραλείψεις, specs και mirrors (#27)

### DIFF
--- a/dtos/invoice/responses/proforma-invoice-response.dto.ts
+++ b/dtos/invoice/responses/proforma-invoice-response.dto.ts
@@ -1,4 +1,10 @@
-import { IsEnum, IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsString,
+  IsUrl,
+  ValidateIf,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
@@ -45,7 +51,14 @@ export class ProformaInvoiceResponseDto extends BaseResponse {
   })
   outboxId!: string;
 
-  /** URL to access the generated invoice document */
+  /**
+   * URL to access the generated invoice document. The three document fields below exist
+   * only on a SUCCESS: a `failure` or `pending` report has no document to describe.
+   */
+  @ValidateIf(
+    (response: ProformaInvoiceResponseDto) =>
+      response.status === ResponseStatusEnum.SUCCESS,
+  )
   @IsUrl()
   @IsNotEmpty()
   @JSONSchema({
@@ -54,9 +67,13 @@ export class ProformaInvoiceResponseDto extends BaseResponse {
     type: 'string',
     format: 'uri',
   })
-  invoiceUrl!: string;
+  invoiceUrl?: string;
 
   /** Invoice number assigned by the integration */
+  @ValidateIf(
+    (response: ProformaInvoiceResponseDto) =>
+      response.status === ResponseStatusEnum.SUCCESS,
+  )
   @IsString()
   @IsNotEmpty()
   @JSONSchema({
@@ -64,9 +81,13 @@ export class ProformaInvoiceResponseDto extends BaseResponse {
     description: 'Invoice number assigned by the integration.',
     type: 'string',
   })
-  invoiceNumber!: string;
+  invoiceNumber?: string;
 
   /** Unique identifier for the invoice in the integration system */
+  @ValidateIf(
+    (response: ProformaInvoiceResponseDto) =>
+      response.status === ResponseStatusEnum.SUCCESS,
+  )
   @IsString()
   @IsNotEmpty()
   @JSONSchema({
@@ -74,5 +95,5 @@ export class ProformaInvoiceResponseDto extends BaseResponse {
     description: 'Unique identifier for the invoice in the integration system.',
     type: 'string',
   })
-  invoiceId!: string;
+  invoiceId?: string;
 }

--- a/dtos/product/responses/product-create-response.dto.ts
+++ b/dtos/product/responses/product-create-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductCreateResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the creation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -20,20 +28,25 @@ export class ProductCreateResponseDto extends BaseResponse {
   status!: ResponseStatusEnum;
 
   /**
-   * The unique identifier of the product item that was created.
+   * The unique identifier of the product item that was created, in the integration's own
+   * system. Optional: the core correlates on `outboxId`, never on this.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was created.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -46,6 +59,8 @@ export class ProductCreateResponseDto extends BaseResponse {
    * Optional data associated with the creation response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the creation response.',

--- a/dtos/product/responses/product-delete-response.dto.ts
+++ b/dtos/product/responses/product-delete-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductDeleteResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the deletion.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,18 +30,22 @@ export class ProductDeleteResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was deleted.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was deleted.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -46,6 +58,8 @@ export class ProductDeleteResponseDto extends BaseResponse {
    * Optional data associated with the deletion response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the deletion response.',

--- a/dtos/product/responses/product-downgradable-response.dto.ts
+++ b/dtos/product/responses/product-downgradable-response.dto.ts
@@ -1,5 +1,6 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +11,7 @@ export class ProductDowngradableResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating success or failure.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description: 'The status of the response, indicating success or failure.',
@@ -21,18 +23,22 @@ export class ProductDowngradableResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item being checked.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item being checked.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * Optional data associated with the Downgradable check.
    * Can contain details about available downgrades or reasons for failure.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the downgradable check.',

--- a/dtos/product/responses/product-downgrade-response.dto.ts
+++ b/dtos/product/responses/product-downgrade-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductDowngradeResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the downgrade.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,19 +30,23 @@ export class ProductDowngradeResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was downgraded.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was downgraded.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -47,6 +59,8 @@ export class ProductDowngradeResponseDto extends BaseResponse {
    * Optional data associated with the downgrade response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the downgrade response.',

--- a/dtos/product/responses/product-renew-response.dto.ts
+++ b/dtos/product/responses/product-renew-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductRenewResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the renewal.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,18 +30,22 @@ export class ProductRenewResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was renewed.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was renewed.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -46,6 +58,8 @@ export class ProductRenewResponseDto extends BaseResponse {
    * Optional data associated with the renewal response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the renewal response.',

--- a/dtos/product/responses/product-suspend-response.dto.ts
+++ b/dtos/product/responses/product-suspend-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductSuspendResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the suspend operation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,19 +30,23 @@ export class ProductSuspendResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was suspended.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was suspended.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -47,6 +59,8 @@ export class ProductSuspendResponseDto extends BaseResponse {
    * Optional data associated with the suspend response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the suspend response.',

--- a/dtos/product/responses/product-unsuspend-response.dto.ts
+++ b/dtos/product/responses/product-unsuspend-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the unsuspend operation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,19 +30,23 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was unsuspended.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was unsuspended.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -47,6 +59,8 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
    * Optional data associated with the unsuspend response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the unsuspend response.',

--- a/dtos/product/responses/product-upgradable-response.dto.ts
+++ b/dtos/product/responses/product-upgradable-response.dto.ts
@@ -1,5 +1,6 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +11,7 @@ export class ProductUpgradableResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating success or failure.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description: 'The status of the response, indicating success or failure.',
@@ -21,18 +23,22 @@ export class ProductUpgradableResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item being checked.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item being checked.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * Optional data associated with the upgradable check.
    * Can contain details about available upgrades or reasons for failure.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the upgradable check.',

--- a/dtos/product/responses/product-upgrade-response.dto.ts
+++ b/dtos/product/responses/product-upgrade-response.dto.ts
@@ -1,5 +1,12 @@
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -10,6 +17,7 @@ export class ProductUpgradeResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the upgrade.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -22,18 +30,22 @@ export class ProductUpgradeResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was upgraded.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was upgraded.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -47,6 +59,8 @@ export class ProductUpgradeResponseDto extends BaseResponse {
    * This could include details about the new subscription or other relevant information.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the upgrade response.',

--- a/llm.txt
+++ b/llm.txt
@@ -789,6 +789,12 @@ Each entry links to a separate file containing the full code and details.
 
 ---
 
+### ProxyActionTaskDto
+**Description:** The body of an ACTION Cloud Task. The task targets the PROXY WORKER, not the integration: the proxy makes the onward call, answers the task, and reports what the integration said on `hookUrl`. Everything the proxy needs travels here — it holds no state and reads no database.
+
+**Source:** `dtos/proxy-action-task.dto.ts`
+
+**Details:** See [llm/dtos/proxyactiontaskdto.md](llm/dtos/proxyactiontaskdto.md)
 
 ## ENUMS
 
@@ -909,6 +915,12 @@ Each entry links to a separate file containing the full code and details.
 
 ---
 
+### InvoiceActionsEnum
+**Description:** The actions an INVOICE integration is called for. Each value is the route the core calls on the integration (`${integration.url}/${action}`), one per issued document type.
+
+**Source:** `enums/invoice/invoice-actions.enum.ts`
+
+**Details:** See [llm/enums/invoiceactionsenum.md](llm/enums/invoiceactionsenum.md)
 
 ## DECORATORS
 
@@ -1563,6 +1575,82 @@ Each entry links to a separate file containing the full code and details.
 
 ---
 
+### validateCreditNoteResponseDto
+**Description:** Validates a credit note response object.
+
+**Source:** `validators/credit-note-response-validator.ts`
+
+**Details:** See [llm/validators/validatecreditnoteresponsedto.md](llm/validators/validatecreditnoteresponsedto.md)
+
+### validateInvoiceResponseDto
+**Description:** Validates an invoice response object.
+
+**Source:** `validators/invoice-response-validator.ts`
+
+**Details:** See [llm/validators/validateinvoiceresponsedto.md](llm/validators/validateinvoiceresponsedto.md)
+
+### validateProductCreateResponseDto
+**Description:** Validates a product create response object.
+
+**Source:** `validators/product-create-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductcreateresponsedto.md](llm/validators/validateproductcreateresponsedto.md)
+
+### validateProductDeleteResponseDto
+**Description:** Validates a product delete response object.
+
+**Source:** `validators/product-delete-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductdeleteresponsedto.md](llm/validators/validateproductdeleteresponsedto.md)
+
+### validateProductDowngradeResponseDto
+**Description:** Validates a product downgrade response object.
+
+**Source:** `validators/product-downgrade-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductdowngraderesponsedto.md](llm/validators/validateproductdowngraderesponsedto.md)
+
+### validateProductRenewResponseDto
+**Description:** Validates a product renew response object.
+
+**Source:** `validators/product-renew-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductrenewresponsedto.md](llm/validators/validateproductrenewresponsedto.md)
+
+### validateProductSuspendResponseDto
+**Description:** Validates a product suspend response object.
+
+**Source:** `validators/product-suspend-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductsuspendresponsedto.md](llm/validators/validateproductsuspendresponsedto.md)
+
+### validateProductUnsuspendResponseDto
+**Description:** Validates a product unsuspend response object.
+
+**Source:** `validators/product-unsuspend-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductunsuspendresponsedto.md](llm/validators/validateproductunsuspendresponsedto.md)
+
+### validateProductUpgradeResponseDto
+**Description:** Validates a product upgrade response object.
+
+**Source:** `validators/product-upgrade-response-validator.ts`
+
+**Details:** See [llm/validators/validateproductupgraderesponsedto.md](llm/validators/validateproductupgraderesponsedto.md)
+
+### validateProformaInvoiceResponseDto
+**Description:** Validates a proforma invoice response object.
+
+**Source:** `validators/proforma-invoice-response-validator.ts`
+
+**Details:** See [llm/validators/validateproformainvoiceresponsedto.md](llm/validators/validateproformainvoiceresponsedto.md)
+
+### validateProxyActionTaskDto
+**Description:** Validates the body of an ACTION Cloud Task, as the proxy worker receives it.
+
+**Source:** `validators/proxy-action-task-validator.ts`
+
+**Details:** See [llm/validators/validateproxyactiontaskdto.md](llm/validators/validateproxyactiontaskdto.md)
 
 ## TRANSFORMERS
 

--- a/llm/dtos/baseinvoicerequestdto.md
+++ b/llm/dtos/baseinvoicerequestdto.md
@@ -1,6 +1,6 @@
 # BaseInvoiceRequestDto
 
-**Description:** Request payload for calculating tax details. Contains company and customer location information for tax rate determination.
+**Description:** This file defines BaseInvoiceRequestDto.
 
 **Source:** `dtos/invoice/requests/base-invoice-request.dto.ts`
 
@@ -15,6 +15,8 @@ import {
   IsEnum,
   IsNumber,
   IsObject,
+  IsOptional,
+  IsString,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -30,6 +32,24 @@ import { CurrencyEnum } from '../../../enums/currency.enum';
  * Contains company and customer location information for tax rate determination.
  */
 export abstract class BaseInvoiceRequestDto {
+  /**
+   * The core's identifier for the document being issued.
+   *
+   * Optional, and echoed back by the integration only as context — the core uses it
+   * as the write target when the outcome arrives, exactly as `ItemDataDto.itemId`
+   * works for product actions. Without it the core has to smuggle its own id
+   * alongside the contract payload (issue #27). NOT the same as `parentInvoiceId`,
+   * which refers to the invoice being credited.
+   */
+  @IsOptional()
+  @IsString()
+  @JSONSchema({
+    title: 'Invoice ID',
+    description: "The core's identifier for the document being issued.",
+    type: 'string',
+  })
+  invoiceId?: string;
+
   /**
    * Company data
    */

--- a/llm/dtos/productcreateresponsedto.md
+++ b/llm/dtos/productcreateresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductCreateResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the creation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -31,20 +33,25 @@ export class ProductCreateResponseDto extends BaseResponse {
   status!: ResponseStatusEnum;
 
   /**
-   * The unique identifier of the product item that was created.
+   * The unique identifier of the product item that was created, in the integration's own
+   * system. Optional: the core correlates on `outboxId`, never on this.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was created.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -57,6 +64,8 @@ export class ProductCreateResponseDto extends BaseResponse {
    * Optional data associated with the creation response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the creation response.',

--- a/llm/dtos/productdeleteresponsedto.md
+++ b/llm/dtos/productdeleteresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductDeleteResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the deletion.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,18 +35,22 @@ export class ProductDeleteResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was deleted.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was deleted.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -57,6 +63,8 @@ export class ProductDeleteResponseDto extends BaseResponse {
    * Optional data associated with the deletion response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the deletion response.',

--- a/llm/dtos/productdowngradableresponsedto.md
+++ b/llm/dtos/productdowngradableresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductDowngradableResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating success or failure.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description: 'The status of the response, indicating success or failure.',
@@ -32,18 +34,22 @@ export class ProductDowngradableResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item being checked.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item being checked.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * Optional data associated with the Downgradable check.
    * Can contain details about available downgrades or reasons for failure.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the downgradable check.',

--- a/llm/dtos/productdowngraderesponsedto.md
+++ b/llm/dtos/productdowngraderesponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductDowngradeResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the downgrade.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,19 +35,23 @@ export class ProductDowngradeResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was downgraded.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was downgraded.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -58,6 +64,8 @@ export class ProductDowngradeResponseDto extends BaseResponse {
    * Optional data associated with the downgrade response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the downgrade response.',

--- a/llm/dtos/productrenewresponsedto.md
+++ b/llm/dtos/productrenewresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductRenewResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the renewal.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,18 +35,22 @@ export class ProductRenewResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was renewed.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was renewed.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -57,6 +63,8 @@ export class ProductRenewResponseDto extends BaseResponse {
    * Optional data associated with the renewal response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the renewal response.',

--- a/llm/dtos/productsuspendresponsedto.md
+++ b/llm/dtos/productsuspendresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductSuspendResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the suspend operation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,19 +35,23 @@ export class ProductSuspendResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was suspended.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was suspended.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -58,6 +64,8 @@ export class ProductSuspendResponseDto extends BaseResponse {
    * Optional data associated with the suspend response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the suspend response.',

--- a/llm/dtos/productunsuspendresponsedto.md
+++ b/llm/dtos/productunsuspendresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the unsuspend operation.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,19 +35,23 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was unsuspended.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description:
       'The unique identifier of the product item that was unsuspended.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -58,6 +64,8 @@ export class ProductUnsuspendResponseDto extends BaseResponse {
    * Optional data associated with the unsuspend response.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the unsuspend response.',

--- a/llm/dtos/productupgradableresponsedto.md
+++ b/llm/dtos/productupgradableresponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductUpgradableResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating success or failure.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description: 'The status of the response, indicating success or failure.',
@@ -32,18 +34,22 @@ export class ProductUpgradableResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item being checked.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item being checked.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * Optional data associated with the upgradable check.
    * Can contain details about available upgrades or reasons for failure.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the upgradable check.',

--- a/llm/dtos/productupgraderesponsedto.md
+++ b/llm/dtos/productupgraderesponsedto.md
@@ -11,6 +11,7 @@
 ```typescript
 import { ResponseStatusEnum } from '../../../enums/response-status.enum';
 import { BaseResponse } from '../../base-response.dto';
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 
 /**
@@ -21,6 +22,7 @@ export class ProductUpgradeResponseDto extends BaseResponse {
   /**
    * The status of the response, indicating the outcome of the upgrade.
    */
+  @IsEnum(ResponseStatusEnum)
   @JSONSchema({
     title: 'Status',
     description:
@@ -33,18 +35,22 @@ export class ProductUpgradeResponseDto extends BaseResponse {
   /**
    * The unique identifier of the product item that was upgraded.
    */
+  @IsOptional()
+  @IsString()
   @JSONSchema({
     title: 'Item ID',
     description: 'The unique identifier of the product item that was upgraded.',
     type: 'string',
   })
-  itemId!: string;
+  itemId?: string;
 
   /**
    * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
    * header sent by the core. Used for correlation and anti-replay when the
    * action completes synchronously or later via a pending hook.
    */
+  @IsString()
+  @IsNotEmpty()
   @JSONSchema({
     title: 'Outbox ID',
     description:
@@ -58,6 +64,8 @@ export class ProductUpgradeResponseDto extends BaseResponse {
    * This could include details about the new subscription or other relevant information.
    * @optional
    */
+  @IsOptional()
+  @IsObject()
   @JSONSchema({
     title: 'Data',
     description: 'Optional data associated with the upgrade response.',

--- a/llm/dtos/proformainvoiceresponsedto.md
+++ b/llm/dtos/proformainvoiceresponsedto.md
@@ -1,6 +1,6 @@
 # ProformaInvoiceResponseDto
 
-**Description:** Response from invoice integrations after successfully creating a proforma invoice. Contains the generated invoice details and access URL.
+**Description:** Response from invoice integrations after issuing a proforma invoice. Contains the generated invoice details and access URL.
 
 **Source:** `dtos/invoice/responses/proforma-invoice-response.dto.ts`
 
@@ -9,15 +9,58 @@
 ## Code
 
 ```typescript
-import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsString, IsUrl, ValidateIf } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
+import { ResponseStatusEnum } from '../../../enums/response-status.enum';
+import { BaseResponse } from '../../base-response.dto';
 
 /**
- * Response from invoice integrations after successfully creating a proforma invoice.
+ * Response from invoice integrations after issuing a proforma invoice.
  * Contains the generated invoice details and access URL.
+ *
+ * Sent BOTH as the synchronous reply and, when the core dispatches the call through
+ * Cloud Tasks, as the body of the deferred hook — the integration reports by posting
+ * this same object back. Mirrors the product responses so both families correlate
+ * and settle the same way (issue #27).
  */
-export class ProformaInvoiceResponseDto {
-  /** URL to access the generated invoice document */
+export class ProformaInvoiceResponseDto extends BaseResponse {
+  /**
+   * The status of the response, indicating the outcome of the issuance.
+   * Without it an integration cannot report a business failure — only success or a
+   * transport-level error.
+   */
+  @IsEnum(ResponseStatusEnum)
+  @JSONSchema({
+    title: 'Status',
+    description:
+      'The status of the response, indicating the outcome of the issuance.',
+    type: 'string',
+    enum: Object.values(ResponseStatusEnum),
+  })
+  status!: ResponseStatusEnum;
+
+  /**
+   * The outbox action identifier, echoed verbatim from the `X-Idempotency-Key`
+   * header sent by the core. Used for correlation and anti-replay when the action
+   * completes synchronously or later via a deferred hook. NOTE: this is the CORE's
+   * id for the action — `invoiceId` below is the document's id in the integration's
+   * own system and is never a correlation key.
+   */
+  @IsString()
+  @IsNotEmpty()
+  @JSONSchema({
+    title: 'Outbox ID',
+    description:
+      'The outbox action identifier, echoed verbatim from the X-Idempotency-Key header sent by the core, used for correlation and anti-replay.',
+    type: 'string',
+  })
+  outboxId!: string;
+
+  /**
+   * URL to access the generated invoice document. The three document fields below exist
+   * only on a SUCCESS: a `failure` or `pending` report has no document to describe.
+   */
+  @ValidateIf((response: ProformaInvoiceResponseDto) => response.status === ResponseStatusEnum.SUCCESS)
   @IsUrl()
   @IsNotEmpty()
   @JSONSchema({
@@ -26,9 +69,10 @@ export class ProformaInvoiceResponseDto {
     type: 'string',
     format: 'uri',
   })
-  invoiceUrl!: string;
+  invoiceUrl?: string;
 
   /** Invoice number assigned by the integration */
+  @ValidateIf((response: ProformaInvoiceResponseDto) => response.status === ResponseStatusEnum.SUCCESS)
   @IsString()
   @IsNotEmpty()
   @JSONSchema({
@@ -36,9 +80,10 @@ export class ProformaInvoiceResponseDto {
     description: 'Invoice number assigned by the integration.',
     type: 'string',
   })
-  invoiceNumber!: string;
+  invoiceNumber?: string;
 
   /** Unique identifier for the invoice in the integration system */
+  @ValidateIf((response: ProformaInvoiceResponseDto) => response.status === ResponseStatusEnum.SUCCESS)
   @IsString()
   @IsNotEmpty()
   @JSONSchema({
@@ -46,6 +91,6 @@ export class ProformaInvoiceResponseDto {
     description: 'Unique identifier for the invoice in the integration system.',
     type: 'string',
   })
-  invoiceId!: string;
+  invoiceId?: string;
 }
 ```

--- a/llm/dtos/proxyactiontaskdto.md
+++ b/llm/dtos/proxyactiontaskdto.md
@@ -1,3 +1,14 @@
+# ProxyActionTaskDto
+
+**Description:** The body of an ACTION Cloud Task. The task targets the PROXY WORKER, not the integration: the proxy makes the onward call, answers the task, and reports what the integration said on `hookUrl`. Everything the proxy needs travels here — it holds no state and reads no database.
+
+**Source:** `dtos/proxy-action-task.dto.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import {
   IsMongoId,
   IsNotEmpty,
@@ -26,7 +37,7 @@ export class ProxyActionTaskDto {
   /**
    * Absolute target of the onward call, action route included (`${integration.url}/${action}`).
    */
-  @IsUrl({ require_tld: false, require_protocol: true })
+  @IsUrl({ require_tld: false })
   @JSONSchema({
     title: 'Integration URL',
     description: 'Absolute URL the proxy calls, action included.',
@@ -49,7 +60,7 @@ export class ProxyActionTaskDto {
    * Where the proxy reports what the integration answered. The integration's own deferred
    * report needs no url: its hooks are public, well-known routes per action.
    */
-  @IsUrl({ require_tld: false, require_protocol: true })
+  @IsUrl({ require_tld: false })
   @JSONSchema({
     title: 'Hook URL',
     description: "The core's proxy hook for this action.",
@@ -77,3 +88,4 @@ export class ProxyActionTaskDto {
   })
   payload!: Record<string, unknown>;
 }
+```

--- a/llm/enums/invoiceactionsenum.md
+++ b/llm/enums/invoiceactionsenum.md
@@ -1,0 +1,21 @@
+# InvoiceActionsEnum
+
+**Description:** The actions an INVOICE integration is called for. Each value is the route the core calls on the integration (`${integration.url}/${action}`), one per issued document type.
+
+**Source:** `enums/invoice/invoice-actions.enum.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
+/**
+ * The actions an INVOICE integration is called for. Each value is the route the core calls
+ * on the integration (`${integration.url}/${action}`), one per issued document type.
+ */
+export enum InvoiceActionsEnum {
+  INVOICE_ISSUE_PROFORMA = 'invoice/proforma',
+  INVOICE_ISSUE_INVOICE = 'invoice/invoice',
+  INVOICE_ISSUE_CREDIT_NOTE = 'invoice/credit-note',
+}
+```

--- a/llm/validators/validatecreditnoteresponsedto.md
+++ b/llm/validators/validatecreditnoteresponsedto.md
@@ -1,9 +1,20 @@
+# validateCreditNoteResponseDto
+
+**Description:** Validates a credit note response object.
+
+**Source:** `validators/credit-note-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { CreditNoteResponseDto } from '../dtos/invoice/responses/credit-note-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a credit note response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateCreditNoteResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(CreditNoteResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateinvoiceresponsedto.md
+++ b/llm/validators/validateinvoiceresponsedto.md
@@ -1,9 +1,20 @@
+# validateInvoiceResponseDto
+
+**Description:** Validates an invoice response object.
+
+**Source:** `validators/invoice-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { InvoiceResponseDto } from '../dtos/invoice/responses/invoice-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates an invoice response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateInvoiceResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(InvoiceResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductcreateresponsedto.md
+++ b/llm/validators/validateproductcreateresponsedto.md
@@ -1,9 +1,20 @@
+# validateProductCreateResponseDto
+
+**Description:** Validates a product create response object.
+
+**Source:** `validators/product-create-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductCreateResponseDto } from '../dtos/product/responses/product-create-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product create response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductCreateResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductCreateResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductdeleteresponsedto.md
+++ b/llm/validators/validateproductdeleteresponsedto.md
@@ -1,9 +1,20 @@
+# validateProductDeleteResponseDto
+
+**Description:** Validates a product delete response object.
+
+**Source:** `validators/product-delete-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductDeleteResponseDto } from '../dtos/product/responses/product-delete-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product delete response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductDeleteResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductDeleteResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductdowngraderesponsedto.md
+++ b/llm/validators/validateproductdowngraderesponsedto.md
@@ -1,9 +1,20 @@
+# validateProductDowngradeResponseDto
+
+**Description:** Validates a product downgrade response object.
+
+**Source:** `validators/product-downgrade-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductDowngradeResponseDto } from '../dtos/product/responses/product-downgrade-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product downgrade response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductDowngradeResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductDowngradeResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductrenewresponsedto.md
+++ b/llm/validators/validateproductrenewresponsedto.md
@@ -1,9 +1,20 @@
+# validateProductRenewResponseDto
+
+**Description:** Validates a product renew response object.
+
+**Source:** `validators/product-renew-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductRenewResponseDto } from '../dtos/product/responses/product-renew-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product renew response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductRenewResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductRenewResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductsuspendresponsedto.md
+++ b/llm/validators/validateproductsuspendresponsedto.md
@@ -1,9 +1,20 @@
+# validateProductSuspendResponseDto
+
+**Description:** Validates a product suspend response object.
+
+**Source:** `validators/product-suspend-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductSuspendResponseDto } from '../dtos/product/responses/product-suspend-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product suspend response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductSuspendResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductSuspendResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductunsuspendresponsedto.md
+++ b/llm/validators/validateproductunsuspendresponsedto.md
@@ -1,9 +1,20 @@
+# validateProductUnsuspendResponseDto
+
+**Description:** Validates a product unsuspend response object.
+
+**Source:** `validators/product-unsuspend-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductUnsuspendResponseDto } from '../dtos/product/responses/product-unsuspend-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product unsuspend response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductUnsuspendResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductUnsuspendResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproductupgraderesponsedto.md
+++ b/llm/validators/validateproductupgraderesponsedto.md
@@ -1,9 +1,20 @@
+# validateProductUpgradeResponseDto
+
+**Description:** Validates a product upgrade response object.
+
+**Source:** `validators/product-upgrade-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
+import { ProductUpgradeResponseDto } from '../dtos/product/responses/product-upgrade-response.dto';
 
 /**
- * Validates a proforma invoice response object.
+ * Validates a product upgrade response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
  * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
@@ -12,9 +23,10 @@ import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-i
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
  */
-export const validateProformaInvoiceResponseDto = async (
+export const validateProductUpgradeResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
-  const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
+  const response = plainToInstance(ProductUpgradeResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproformainvoiceresponsedto.md
+++ b/llm/validators/validateproformainvoiceresponsedto.md
@@ -1,3 +1,14 @@
+# validateProformaInvoiceResponseDto
+
+**Description:** Validates a proforma invoice response object.
+
+**Source:** `validators/proforma-invoice-response-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
 import { validate, ValidationError } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { ProformaInvoiceResponseDto } from '../dtos/invoice/responses/proforma-invoice-response.dto';
@@ -18,3 +29,4 @@ export const validateProformaInvoiceResponseDto = async (
   const response = plainToInstance(ProformaInvoiceResponseDto, plainObject);
   return await validate(response);
 };
+```

--- a/llm/validators/validateproxyactiontaskdto.md
+++ b/llm/validators/validateproxyactiontaskdto.md
@@ -1,0 +1,28 @@
+# validateProxyActionTaskDto
+
+**Description:** Validates the body of an ACTION Cloud Task, as the proxy worker receives it.
+
+**Source:** `validators/proxy-action-task-validator.ts`
+
+**Language:** typescript
+
+## Code
+
+```typescript
+import { validate, ValidationError } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { ProxyActionTaskDto } from '../dtos/proxy-action-task.dto';
+
+/**
+ * Validates the body of an ACTION Cloud Task, as the proxy worker receives it.
+ *
+ * @param {Record<string, unknown>} plainObject - The plain object to validate.
+ * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
+ */
+export const validateProxyActionTaskDto = async (
+  plainObject: Record<string, unknown>,
+): Promise<ValidationError[]> => {
+  const task = plainToInstance(ProxyActionTaskDto, plainObject);
+  return await validate(task);
+};
+```

--- a/openapi/schemas/components.schemas.ts
+++ b/openapi/schemas/components.schemas.ts
@@ -1,3073 +1,2963 @@
 export const ComponentsSchemas = {
-  "CountryDto": {
-    "properties": {
-      "name": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Name",
-        "description": "Country name."
+  CountryDto: {
+    properties: {
+      name: {
+        minLength: 1,
+        type: 'string',
+        title: 'Name',
+        description: 'Country name.',
       },
-      "code": {
-        "$ref": "#/components/schemas/CountryEnum"
+      code: {
+        $ref: '#/components/schemas/CountryEnum',
       },
-      "isEurope": {
-        "type": "boolean",
-        "title": "Is Europe",
-        "description": "Whether the country is in Europe."
-      }
+      isEurope: {
+        type: 'boolean',
+        title: 'Is Europe',
+        description: 'Whether the country is in Europe.',
+      },
     },
-    "type": "object",
-    "required": [
-      "name",
-      "code"
-    ]
+    type: 'object',
+    required: ['name', 'code'],
   },
-  "TabDto": {
-    "properties": {
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Text label for the tab."
+  TabDto: {
+    properties: {
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Text label for the tab.',
       },
-      "url": {
-        "minLength": 1,
-        "type": "string",
-        "format": "uri",
-        "title": "URL",
-        "description": "URL associated with the tab."
-      }
+      url: {
+        minLength: 1,
+        type: 'string',
+        format: 'uri',
+        title: 'URL',
+        description: 'URL associated with the tab.',
+      },
     },
-    "type": "object",
-    "required": [
-      "label",
-      "url"
-    ]
+    type: 'object',
+    required: ['label', 'url'],
   },
-  "ActionDto": {
-    "properties": {
-      "icon": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Icon",
-        "description": "Name of the icon to display for the action."
+  ActionDto: {
+    properties: {
+      icon: {
+        minLength: 1,
+        type: 'string',
+        title: 'Icon',
+        description: 'Name of the icon to display for the action.',
       },
-      "label": {
-        "type": "string",
-        "title": "Label",
-        "description": "Text label for the action."
+      label: {
+        type: 'string',
+        title: 'Label',
+        description: 'Text label for the action.',
       },
-      "openMethod": {
-        "$ref": "#/components/schemas/OpenMethodEnum"
+      openMethod: {
+        $ref: '#/components/schemas/OpenMethodEnum',
       },
-      "url": {
-        "minLength": 1,
-        "type": "string",
-        "format": "url",
-        "title": "URL",
-        "description": "URL to navigate to when the action is triggered."
-      }
+      url: {
+        minLength: 1,
+        type: 'string',
+        format: 'url',
+        title: 'URL',
+        description: 'URL to navigate to when the action is triggered.',
+      },
     },
-    "type": "object",
-    "required": [
-      "icon",
-      "openMethod",
-      "url"
-    ]
+    type: 'object',
+    required: ['icon', 'openMethod', 'url'],
   },
-  "BaseMenuDto": {
-    "properties": {
-      "icon": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon for the menu item."
+  BaseMenuDto: {
+    properties: {
+      icon: {
+        minLength: 1,
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon for the menu item.',
       },
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label for the menu item."
-      }
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label for the menu item.',
+      },
     },
-    "type": "object",
-    "required": [
-      "icon",
-      "label"
-    ]
+    type: 'object',
+    required: ['icon', 'label'],
   },
-  "MenuDtoWithUrl": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "only-url"
-        ],
-        "minLength": 1,
-        "title": "Type",
-        "description": "Type of the menu item."
+  MenuDtoWithUrl: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['only-url'],
+        minLength: 1,
+        title: 'Type',
+        description: 'Type of the menu item.',
       },
-      "url": {
-        "minLength": 1,
-        "type": "string",
-        "format": "uri",
-        "title": "URL",
-        "description": "URL associated with the menu item."
+      url: {
+        minLength: 1,
+        type: 'string',
+        format: 'uri',
+        title: 'URL',
+        description: 'URL associated with the menu item.',
       },
-      "icon": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon for the menu item."
+      icon: {
+        minLength: 1,
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon for the menu item.',
       },
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label for the menu item."
-      }
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label for the menu item.',
+      },
     },
-    "type": "object",
-    "required": [
-      "type",
-      "url",
-      "submenu",
-      "icon",
-      "label"
-    ]
+    type: 'object',
+    required: ['type', 'url', 'submenu', 'icon', 'label'],
   },
-  "MenuDtoWithSubmenu": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "with-submenu"
-        ],
-        "minLength": 1,
-        "title": "Type",
-        "description": "Type of the menu item."
+  MenuDtoWithSubmenu: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['with-submenu'],
+        minLength: 1,
+        title: 'Type',
+        description: 'Type of the menu item.',
       },
-      "submenu": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+      submenu: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "type": "array",
-        "title": "Submenu",
-        "description": "List of tabs that will appear in the submenu."
+        type: 'array',
+        title: 'Submenu',
+        description: 'List of tabs that will appear in the submenu.',
       },
-      "icon": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon for the menu item."
+      icon: {
+        minLength: 1,
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon for the menu item.',
       },
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label for the menu item."
-      }
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label for the menu item.',
+      },
     },
-    "type": "object",
-    "required": [
-      "type",
-      "url",
-      "submenu",
-      "icon",
-      "label"
-    ]
+    type: 'object',
+    required: ['type', 'url', 'submenu', 'icon', 'label'],
   },
-  "SettingsDto": {
-    "properties": {
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label of the settings page."
+  SettingsDto: {
+    properties: {
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label of the settings page.',
       },
-      "icon": {
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon of the settings page."
+      icon: {
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon of the settings page.',
       },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Description of the settings page."
-      }
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Description of the settings page.',
+      },
     },
-    "type": "object",
-    "required": [
-      "label",
-      "icon",
-      "description"
-    ]
+    type: 'object',
+    required: ['label', 'icon', 'description'],
   },
-  "SettingsWithUrlDto": {
-    "properties": {
-      "url": {
-        "format": "url",
-        "type": "string",
-        "title": "URL",
-        "description": "URL to the settings page."
+  SettingsWithUrlDto: {
+    properties: {
+      url: {
+        format: 'url',
+        type: 'string',
+        title: 'URL',
+        description: 'URL to the settings page.',
       },
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label of the settings page."
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label of the settings page.',
       },
-      "icon": {
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon of the settings page."
+      icon: {
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon of the settings page.',
       },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Description of the settings page."
-      }
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Description of the settings page.',
+      },
     },
-    "type": "object",
-    "required": [
-      "url",
-      "tabs",
-      "label",
-      "icon",
-      "description"
-    ]
+    type: 'object',
+    required: ['url', 'tabs', 'label', 'icon', 'description'],
   },
-  "SettingsWithTabsDto": {
-    "properties": {
-      "tabs": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+  SettingsWithTabsDto: {
+    properties: {
+      tabs: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "type": "array",
-        "title": "Tabs",
-        "description": "List of tabs for the settings page."
+        type: 'array',
+        title: 'Tabs',
+        description: 'List of tabs for the settings page.',
       },
-      "label": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Label",
-        "description": "Label of the settings page."
+      label: {
+        minLength: 1,
+        type: 'string',
+        title: 'Label',
+        description: 'Label of the settings page.',
       },
-      "icon": {
-        "type": "string",
-        "title": "Icon",
-        "description": "Icon of the settings page."
+      icon: {
+        type: 'string',
+        title: 'Icon',
+        description: 'Icon of the settings page.',
       },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Description of the settings page."
-      }
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Description of the settings page.',
+      },
     },
-    "type": "object",
-    "required": [
-      "tabs",
-      "url",
-      "label",
-      "icon",
-      "description"
-    ]
+    type: 'object',
+    required: ['tabs', 'url', 'label', 'icon', 'description'],
   },
-  "AdminPanelTabsDto": {
-    "properties": {
-      "product": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+  AdminPanelTabsDto: {
+    properties: {
+      product: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Product Tabs",
-        "description": "Tabs shown on the product detail page in Admin panel."
+        minItems: 1,
+        type: 'array',
+        title: 'Product Tabs',
+        description: 'Tabs shown on the product detail page in Admin panel.',
       },
-      "item": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+      item: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Item Tabs",
-        "description": "Tabs shown on the item detail page in Admin panel."
+        minItems: 1,
+        type: 'array',
+        title: 'Item Tabs',
+        description: 'Tabs shown on the item detail page in Admin panel.',
       },
-      "client": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+      client: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Client Tabs",
-        "description": "Tabs shown on the client profile page in Admin panel."
+        minItems: 1,
+        type: 'array',
+        title: 'Client Tabs',
+        description: 'Tabs shown on the client profile page in Admin panel.',
       },
-      "user": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+      user: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "User Tabs",
-        "description": "Tabs shown on the user page in Admin panel."
+        minItems: 1,
+        type: 'array',
+        title: 'User Tabs',
+        description: 'Tabs shown on the user page in Admin panel.',
       },
-      "order": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
+      order: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Order Tabs",
-        "description": "Tabs shown on the order page in Admin panel."
-      }
+        minItems: 1,
+        type: 'array',
+        title: 'Order Tabs',
+        description: 'Tabs shown on the order page in Admin panel.',
+      },
     },
-    "type": "object"
+    type: 'object',
   },
-  "AdminPanelMoreActionsDto": {
-    "properties": {
-      "client": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
+  AdminPanelMoreActionsDto: {
+    properties: {
+      client: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
         },
-        "type": "array",
-        "minItems": 1,
-        "title": "Client Actions",
-        "description": "Additional actions available on the client page."
+        type: 'array',
+        minItems: 1,
+        title: 'Client Actions',
+        description: 'Additional actions available on the client page.',
       },
-      "item": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
+      item: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
         },
-        "type": "array",
-        "minItems": 1,
-        "title": "Item Actions",
-        "description": "Additional actions available on the item page."
+        type: 'array',
+        minItems: 1,
+        title: 'Item Actions',
+        description: 'Additional actions available on the item page.',
       },
-      "invoice": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
+      invoice: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
         },
-        "type": "array",
-        "minItems": 1,
-        "title": "Invoice Actions",
-        "description": "Additional actions available on the invoice page."
+        type: 'array',
+        minItems: 1,
+        title: 'Invoice Actions',
+        description: 'Additional actions available on the invoice page.',
       },
-      "user": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
+      user: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
         },
-        "type": "array",
-        "minItems": 1,
-        "title": "User Actions",
-        "description": "Additional actions available on the user page."
+        type: 'array',
+        minItems: 1,
+        title: 'User Actions',
+        description: 'Additional actions available on the user page.',
       },
-      "order": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
+      order: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
         },
-        "type": "array",
-        "minItems": 1,
-        "title": "Order Actions",
-        "description": "Additional actions available on the order page."
-      }
+        type: 'array',
+        minItems: 1,
+        title: 'Order Actions',
+        description: 'Additional actions available on the order page.',
+      },
     },
-    "type": "object"
+    type: 'object',
   },
-  "AdminPanelDto": {
-    "properties": {
-      "tabs": {
-        "$ref": "#/components/schemas/AdminPanelTabsDto"
+  AdminPanelDto: {
+    properties: {
+      tabs: {
+        $ref: '#/components/schemas/AdminPanelTabsDto',
       },
-      "moreActions": {
-        "$ref": "#/components/schemas/AdminPanelMoreActionsDto"
+      moreActions: {
+        $ref: '#/components/schemas/AdminPanelMoreActionsDto',
       },
-      "menu": {
-        "title": "Menu",
-        "description": "Admin panel main menu (URL or submenu variant).",
-        "type": "object",
-        "oneOf": [
+      menu: {
+        title: 'Menu',
+        description: 'Admin panel main menu (URL or submenu variant).',
+        type: 'object',
+        oneOf: [
           {
-            "$ref": "#/components/schemas/MenuDtoWithSubmenu"
+            $ref: '#/components/schemas/MenuDtoWithSubmenu',
           },
           {
-            "$ref": "#/components/schemas/MenuDtoWithUrl"
-          }
-        ]
+            $ref: '#/components/schemas/MenuDtoWithUrl',
+          },
+        ],
       },
-      "settings": {
-        "title": "Settings",
-        "description": "Admin panel settings page configuration.",
-        "type": "object",
-        "oneOf": [
+      settings: {
+        title: 'Settings',
+        description: 'Admin panel settings page configuration.',
+        type: 'object',
+        oneOf: [
           {
-            "$ref": "#/components/schemas/SettingsWithUrlDto"
+            $ref: '#/components/schemas/SettingsWithUrlDto',
           },
           {
-            "$ref": "#/components/schemas/SettingsWithTabsDto"
-          }
-        ]
-      }
-    },
-    "type": "object"
-  },
-  "ClientPanelTabsDto": {
-    "properties": {
-      "item": {
-        "items": {
-          "$ref": "#/components/schemas/TabDto"
-        },
-        "type": "array",
-        "minItems": 1,
-        "title": "Item Tabs",
-        "description": "Tabs shown on the item page in Client panel."
-      }
-    },
-    "type": "object"
-  },
-  "ClientPanelMoreActionsDto": {
-    "properties": {
-      "item": {
-        "items": {
-          "$ref": "#/components/schemas/ActionDto"
-        },
-        "type": "array",
-        "minItems": 1,
-        "title": "Item Actions",
-        "description": "Additional actions available on the item page in Client panel."
-      }
-    },
-    "type": "object"
-  },
-  "ClientPanelDto": {
-    "properties": {
-      "tabs": {
-        "$ref": "#/components/schemas/ClientPanelTabsDto"
+            $ref: '#/components/schemas/SettingsWithTabsDto',
+          },
+        ],
       },
-      "moreActions": {
-        "$ref": "#/components/schemas/ClientPanelMoreActionsDto"
+    },
+    type: 'object',
+  },
+  ClientPanelTabsDto: {
+    properties: {
+      item: {
+        items: {
+          $ref: '#/components/schemas/TabDto',
+        },
+        type: 'array',
+        minItems: 1,
+        title: 'Item Tabs',
+        description: 'Tabs shown on the item page in Client panel.',
       },
-      "menu": {
-        "title": "Menu",
-        "description": "Client panel main menu (URL or submenu variant).",
-        "oneOf": [
+    },
+    type: 'object',
+  },
+  ClientPanelMoreActionsDto: {
+    properties: {
+      item: {
+        items: {
+          $ref: '#/components/schemas/ActionDto',
+        },
+        type: 'array',
+        minItems: 1,
+        title: 'Item Actions',
+        description:
+          'Additional actions available on the item page in Client panel.',
+      },
+    },
+    type: 'object',
+  },
+  ClientPanelDto: {
+    properties: {
+      tabs: {
+        $ref: '#/components/schemas/ClientPanelTabsDto',
+      },
+      moreActions: {
+        $ref: '#/components/schemas/ClientPanelMoreActionsDto',
+      },
+      menu: {
+        title: 'Menu',
+        description: 'Client panel main menu (URL or submenu variant).',
+        oneOf: [
           {
-            "$ref": "#/components/schemas/MenuDtoWithSubmenu"
+            $ref: '#/components/schemas/MenuDtoWithSubmenu',
           },
           {
-            "$ref": "#/components/schemas/MenuDtoWithUrl"
-          }
-        ]
-      }
-    },
-    "type": "object"
-  },
-  "InfoDto": {
-    "properties": {
-      "title": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Title",
-        "description": "Integration display title.",
-        "example": "Example Product"
-      },
-      "logo": {
-        "format": "uri",
-        "type": "string",
-        "title": "Logo URL",
-        "description": "Public HTTPS URL for the integration logo.",
-        "example": "https://cdn.example.com/logo.png"
-      },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Short description of the integration.",
-        "example": "An example product integration."
-      },
-      "supportedLanguages": {
-        "items": {
-          "$ref": "#/components/schemas/LanguageEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Supported Languages",
-        "description": "Locales supported by the integration.",
-        "example": [
-          "EN"
-        ]
-      },
-      "listenEvents": {
-        "items": {
-          "$ref": "#/components/schemas/EventsEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Listen Events",
-        "description": "Platform events the integration can subscribe to."
-      },
-      "requiredRoles": {
-        "items": {
-          "$ref": "#/components/schemas/RolesEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Required Roles",
-        "description": "Roles required for this integration to operate."
-      },
-      "adminPanel": {
-        "$ref": "#/components/schemas/AdminPanelDto"
-      },
-      "clientPanel": {
-        "$ref": "#/components/schemas/ClientPanelDto"
-      },
-      "onboardingUrl": {
-        "format": "uri",
-        "type": "string",
-        "title": "Onboarding URL",
-        "description": "URL to onboard/configure the integration.",
-        "example": "https://example.com/onboarding"
-      },
-      "setupAttributes": {
-        "items": {
-          "$ref": "#/components/schemas/AnyFieldDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Setup Attributes",
-        "description": "Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal."
-      }
-    },
-    "type": "object",
-    "required": [
-      "title",
-      "supportedLanguages"
-    ]
-  },
-  "UnitDto": {
-    "properties": {
-      "id": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Unit ID",
-        "description": "Unit identifier.",
-        "example": "messages"
-      },
-      "unitDescription": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Unit Description",
-        "description": "What is measured.",
-        "example": "Message sent"
-      },
-      "intervalDescription": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Interval Description",
-        "description": "Billing interval.",
-        "example": "Per month"
-      }
-    },
-    "type": "object",
-    "required": [
-      "id",
-      "unitDescription",
-      "intervalDescription"
-    ]
-  },
-  "NotificationInfoDto": {
-    "properties": {
-      "type": {
-        "$ref": "#/components/schemas/NotificationMessageTypeEnum"
-      },
-      "payPerUseUnits": {
-        "items": {
-          "$ref": "#/components/schemas/UnitDto"
-        },
-        "type": "array",
-        "title": "Pay-Per-Use Units",
-        "description": "Optional metering units for pay-per-use billing.",
-        "example": [
-          {
-            "id": "messages",
-            "unitDescription": "Message sent",
-            "intervalDescription": "Per month"
-          }
-        ]
-      },
-      "title": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Title",
-        "description": "Integration display title.",
-        "example": "Example Product"
-      },
-      "logo": {
-        "format": "uri",
-        "type": "string",
-        "title": "Logo URL",
-        "description": "Public HTTPS URL for the integration logo.",
-        "example": "https://cdn.example.com/logo.png"
-      },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Short description of the integration.",
-        "example": "An example product integration."
-      },
-      "supportedLanguages": {
-        "items": {
-          "$ref": "#/components/schemas/LanguageEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Supported Languages",
-        "description": "Locales supported by the integration.",
-        "example": [
-          "EN"
-        ]
-      },
-      "listenEvents": {
-        "items": {
-          "$ref": "#/components/schemas/EventsEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Listen Events",
-        "description": "Platform events the integration can subscribe to."
-      },
-      "requiredRoles": {
-        "items": {
-          "$ref": "#/components/schemas/RolesEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Required Roles",
-        "description": "Roles required for this integration to operate."
-      },
-      "adminPanel": {
-        "$ref": "#/components/schemas/AdminPanelDto"
-      },
-      "clientPanel": {
-        "$ref": "#/components/schemas/ClientPanelDto"
-      },
-      "onboardingUrl": {
-        "format": "uri",
-        "type": "string",
-        "title": "Onboarding URL",
-        "description": "URL to onboard/configure the integration.",
-        "example": "https://example.com/onboarding"
-      },
-      "setupAttributes": {
-        "items": {
-          "$ref": "#/components/schemas/AnyFieldDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Setup Attributes",
-        "description": "Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal."
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "title",
-      "supportedLanguages"
-    ]
-  },
-  "AttributeFieldDto": {
-    "properties": {
-      "field": {
-        "$ref": "#/components/schemas/AnyFieldDto"
-      },
-      "visibleInOrder": {
-        "type": "boolean",
-        "title": "Visible In Order",
-        "description": "Whether the field is visible in order view."
-      },
-      "visibleInClientPanel": {
-        "type": "boolean",
-        "title": "Visible In Client Panel",
-        "description": "Whether the field is visible in the client panel."
-      },
-      "repeatableMin": {
-        "type": "number",
-        "title": "Repeatable Min",
-        "description": "Minimum repeats for repeatable fields."
-      },
-      "repeatableMax": {
-        "type": "number",
-        "title": "Repeatable Max",
-        "description": "Maximum repeats for repeatable fields."
-      }
-    },
-    "type": "object",
-    "required": [
-      "field"
-    ]
-  },
-  "ProductInfoDto": {
-    "properties": {
-      "productAttributes": {
-        "items": {
-          "$ref": "#/components/schemas/AttributeFieldDto"
-        },
-        "type": "array",
-        "minItems": 1,
-        "title": "Product Attributes",
-        "description": "Configurable attributes that apply at the product level."
-      },
-      "itemAttributes": {
-        "items": {
-          "$ref": "#/components/schemas/AttributeFieldDto"
-        },
-        "type": "array",
-        "minItems": 1,
-        "title": "Item Attributes",
-        "description": "Configurable attributes that apply at the item level."
-      },
-      "payPerUseUnits": {
-        "items": {
-          "$ref": "#/components/schemas/UnitDto"
-        },
-        "type": "array",
-        "minItems": 1,
-        "title": "Pay-Per-Use Units",
-        "description": "Optional metering units for pay-per-use billing.",
-        "example": [
-          {
-            "id": "requests",
-            "unitDescription": "API request",
-            "intervalDescription": "Per month"
-          }
-        ]
-      },
-      "responseDataFieldNames": {
-        "title": "Response Data Field Names",
-        "description": "Mapping of field names used in provider responses.",
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        },
-        "example": {
-          "external_id": "id",
-          "status_text": "status"
-        }
-      },
-      "supportedActions": {
-        "items": {
-          "$ref": "#/components/schemas/ProductActionsEnum"
-        },
-        "type": "array",
-        "minLength": 1,
-        "title": "Supported Actions",
-        "description": "Actions supported by this integration."
-      },
-      "title": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Title",
-        "description": "Integration display title.",
-        "example": "Example Product"
-      },
-      "logo": {
-        "format": "uri",
-        "type": "string",
-        "title": "Logo URL",
-        "description": "Public HTTPS URL for the integration logo.",
-        "example": "https://cdn.example.com/logo.png"
-      },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "Short description of the integration.",
-        "example": "An example product integration."
-      },
-      "supportedLanguages": {
-        "items": {
-          "$ref": "#/components/schemas/LanguageEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Supported Languages",
-        "description": "Locales supported by the integration.",
-        "example": [
-          "EN"
-        ]
-      },
-      "listenEvents": {
-        "items": {
-          "$ref": "#/components/schemas/EventsEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Listen Events",
-        "description": "Platform events the integration can subscribe to."
-      },
-      "requiredRoles": {
-        "items": {
-          "$ref": "#/components/schemas/RolesEnum"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Required Roles",
-        "description": "Roles required for this integration to operate."
-      },
-      "adminPanel": {
-        "$ref": "#/components/schemas/AdminPanelDto"
-      },
-      "clientPanel": {
-        "$ref": "#/components/schemas/ClientPanelDto"
-      },
-      "onboardingUrl": {
-        "format": "uri",
-        "type": "string",
-        "title": "Onboarding URL",
-        "description": "URL to onboard/configure the integration.",
-        "example": "https://example.com/onboarding"
-      },
-      "setupAttributes": {
-        "items": {
-          "$ref": "#/components/schemas/AnyFieldDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Setup Attributes",
-        "description": "Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal."
-      }
-    },
-    "type": "object",
-    "required": [
-      "supportedActions",
-      "title",
-      "supportedLanguages"
-    ]
-  },
-  "MultilangTextDto": {
-    "properties": {
-      "language": {
-        "$ref": "#/components/schemas/LanguageEnum"
-      },
-      "text": {
-        "minLength": 1,
-        "type": "string",
-        "title": "Text",
-        "description": "The text content in the specified language."
-      }
-    },
-    "type": "object",
-    "required": [
-      "language",
-      "text"
-    ]
-  },
-  "BaseFieldDto": {
-    "properties": {
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "BooleanFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "BOOLEAN"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'BOOLEAN' for this DTO."
-      },
-      "value": {
-        "type": "boolean",
-        "title": "Value",
-        "description": "Boolean value of the field."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "TextFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "TEXT"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'TEXT' for this DTO."
-      },
-      "value": {
-        "type": "string",
-        "title": "Value",
-        "description": "Text value of the field."
-      },
-      "minLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Minimum Length",
-        "description": "Minimum allowed character length."
-      },
-      "maxLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Maximum Length",
-        "description": "Maximum allowed character length."
-      },
-      "regexValidation": {
-        "type": "string",
-        "title": "Regex Validation",
-        "description": "Optional regex to validate input.",
-        "example": "^[A-Za-z0-9_-]+$"
-      },
-      "regexValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Regex Validation Error Message",
-        "description": "Localized error message shown when regex validation fails."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "TextareaFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "TEXTAREA"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'TEXTAREA' for this DTO."
-      },
-      "value": {
-        "type": "string",
-        "title": "Value",
-        "description": "Text value of the field."
-      },
-      "minLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Minimum Length",
-        "description": "Minimum allowed character length."
-      },
-      "maxLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Maximum Length",
-        "description": "Maximum allowed character length."
-      },
-      "regexValidation": {
-        "type": "string",
-        "title": "Regex Validation",
-        "description": "Optional regex to validate input.",
-        "example": "^[A-Za-z0-9_-]+$"
-      },
-      "regexValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Regex Validation Error Message",
-        "description": "Localized error message shown when regex validation fails."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "NumberFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "NUMBER"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'NUMBER' for this DTO."
-      },
-      "value": {
-        "type": "number",
-        "title": "Value",
-        "description": "Numeric value of the field."
-      },
-      "min": {
-        "type": "number",
-        "title": "Minimum",
-        "description": "Minimum allowed value."
-      },
-      "max": {
-        "type": "number",
-        "title": "Maximum",
-        "description": "Maximum allowed value."
-      },
-      "integer": {
-        "type": "boolean",
-        "title": "Integer Only",
-        "description": "When true, only integer values are allowed."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "PhoneFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "PHONE"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'PHONE' for this DTO."
-      },
-      "value": {
-        "type": "string",
-        "title": "Value",
-        "description": "Phone number in E.164 format (e.g. +14155552671).",
-        "example": "+14155552671"
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "EmailFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "EMAIL"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'EMAIL' for this DTO."
-      },
-      "value": {
-        "format": "email",
-        "type": "string",
-        "title": "Value",
-        "description": "Email address."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "UrlFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "URL"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'URL' for this DTO."
-      },
-      "value": {
-        "format": "uri",
-        "type": "string",
-        "title": "Value",
-        "description": "URL."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "CountriesFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "COUNTRIES"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'COUNTRIES' for this DTO."
-      },
-      "value": {
-        "items": {
-          "$ref": "#/components/schemas/CountryEnum"
-        },
-        "type": "array",
-        "title": "Value",
-        "description": "Array of ISO 3166-1 alpha-2 country codes."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "CurrencyFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "CURRENCY"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'CURRENCY' for this DTO."
-      },
-      "value": {
-        "$ref": "#/components/schemas/CurrencyEnum"
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "DateFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "DATE"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'DATE' for this DTO."
-      },
-      "value": {
-        "oneOf": [
-          {
-            "format": "date",
-            "type": "string"
+            $ref: '#/components/schemas/MenuDtoWithUrl',
           },
+        ],
+      },
+    },
+    type: 'object',
+  },
+  InfoDto: {
+    properties: {
+      title: {
+        minLength: 1,
+        type: 'string',
+        title: 'Title',
+        description: 'Integration display title.',
+        example: 'Example Product',
+      },
+      logo: {
+        format: 'uri',
+        type: 'string',
+        title: 'Logo URL',
+        description: 'Public HTTPS URL for the integration logo.',
+        example: 'https://cdn.example.com/logo.png',
+      },
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Short description of the integration.',
+        example: 'An example product integration.',
+      },
+      supportedLanguages: {
+        items: {
+          $ref: '#/components/schemas/LanguageEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Supported Languages',
+        description: 'Locales supported by the integration.',
+        example: ['EN'],
+      },
+      listenEvents: {
+        items: {
+          $ref: '#/components/schemas/EventsEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Listen Events',
+        description: 'Platform events the integration can subscribe to.',
+      },
+      requiredRoles: {
+        items: {
+          $ref: '#/components/schemas/RolesEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Required Roles',
+        description: 'Roles required for this integration to operate.',
+      },
+      adminPanel: {
+        $ref: '#/components/schemas/AdminPanelDto',
+      },
+      clientPanel: {
+        $ref: '#/components/schemas/ClientPanelDto',
+      },
+      onboardingUrl: {
+        format: 'uri',
+        type: 'string',
+        title: 'Onboarding URL',
+        description: 'URL to onboard/configure the integration.',
+        example: 'https://example.com/onboarding',
+      },
+      setupAttributes: {
+        items: {
+          $ref: '#/components/schemas/AnyFieldDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Setup Attributes',
+        description:
+          'Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal.',
+      },
+    },
+    type: 'object',
+    required: ['title', 'supportedLanguages'],
+  },
+  UnitDto: {
+    properties: {
+      id: {
+        minLength: 1,
+        type: 'string',
+        title: 'Unit ID',
+        description: 'Unit identifier.',
+        example: 'messages',
+      },
+      unitDescription: {
+        minLength: 1,
+        type: 'string',
+        title: 'Unit Description',
+        description: 'What is measured.',
+        example: 'Message sent',
+      },
+      intervalDescription: {
+        minLength: 1,
+        type: 'string',
+        title: 'Interval Description',
+        description: 'Billing interval.',
+        example: 'Per month',
+      },
+    },
+    type: 'object',
+    required: ['id', 'unitDescription', 'intervalDescription'],
+  },
+  NotificationInfoDto: {
+    properties: {
+      type: {
+        $ref: '#/components/schemas/NotificationMessageTypeEnum',
+      },
+      payPerUseUnits: {
+        items: {
+          $ref: '#/components/schemas/UnitDto',
+        },
+        type: 'array',
+        title: 'Pay-Per-Use Units',
+        description: 'Optional metering units for pay-per-use billing.',
+        example: [
           {
-            "format": "date-time",
-            "type": "string"
-          }
+            id: 'messages',
+            unitDescription: 'Message sent',
+            intervalDescription: 'Per month',
+          },
         ],
-        "title": "Value",
-        "description": "ISO 8601 date or date-time string.",
-        "type": "string",
-        "format": "date-time"
       },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
+      title: {
+        minLength: 1,
+        type: 'string',
+        title: 'Title',
+        description: 'Integration display title.',
+        example: 'Example Product',
       },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
+      logo: {
+        format: 'uri',
+        type: 'string',
+        title: 'Logo URL',
+        description: 'Public HTTPS URL for the integration logo.',
+        example: 'https://cdn.example.com/logo.png',
+      },
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Short description of the integration.',
+        example: 'An example product integration.',
+      },
+      supportedLanguages: {
+        items: {
+          $ref: '#/components/schemas/LanguageEnum',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
+        minItems: 1,
+        type: 'array',
+        title: 'Supported Languages',
+        description: 'Locales supported by the integration.',
+        example: ['EN'],
       },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
+      listenEvents: {
+        items: {
+          $ref: '#/components/schemas/EventsEnum',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
+        minItems: 1,
+        type: 'array',
+        title: 'Listen Events',
+        description: 'Platform events the integration can subscribe to.',
       },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
+      requiredRoles: {
+        items: {
+          $ref: '#/components/schemas/RolesEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Required Roles',
+        description: 'Roles required for this integration to operate.',
       },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
+      adminPanel: {
+        $ref: '#/components/schemas/AdminPanelDto',
+      },
+      clientPanel: {
+        $ref: '#/components/schemas/ClientPanelDto',
+      },
+      onboardingUrl: {
+        format: 'uri',
+        type: 'string',
+        title: 'Onboarding URL',
+        description: 'URL to onboard/configure the integration.',
+        example: 'https://example.com/onboarding',
+      },
+      setupAttributes: {
+        items: {
+          $ref: '#/components/schemas/AnyFieldDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Setup Attributes',
+        description:
+          'Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal.',
+      },
     },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
+    type: 'object',
+    required: ['type', 'title', 'supportedLanguages'],
   },
-  "PasswordFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "PASSWORD"
+  AttributeFieldDto: {
+    properties: {
+      field: {
+        $ref: '#/components/schemas/AnyFieldDto',
+      },
+      visibleInOrder: {
+        type: 'boolean',
+        title: 'Visible In Order',
+        description: 'Whether the field is visible in order view.',
+      },
+      visibleInClientPanel: {
+        type: 'boolean',
+        title: 'Visible In Client Panel',
+        description: 'Whether the field is visible in the client panel.',
+      },
+      repeatableMin: {
+        type: 'number',
+        title: 'Repeatable Min',
+        description: 'Minimum repeats for repeatable fields.',
+      },
+      repeatableMax: {
+        type: 'number',
+        title: 'Repeatable Max',
+        description: 'Maximum repeats for repeatable fields.',
+      },
+    },
+    type: 'object',
+    required: ['field'],
+  },
+  ProductInfoDto: {
+    properties: {
+      productAttributes: {
+        items: {
+          $ref: '#/components/schemas/AttributeFieldDto',
+        },
+        type: 'array',
+        minItems: 1,
+        title: 'Product Attributes',
+        description: 'Configurable attributes that apply at the product level.',
+      },
+      itemAttributes: {
+        items: {
+          $ref: '#/components/schemas/AttributeFieldDto',
+        },
+        type: 'array',
+        minItems: 1,
+        title: 'Item Attributes',
+        description: 'Configurable attributes that apply at the item level.',
+      },
+      payPerUseUnits: {
+        items: {
+          $ref: '#/components/schemas/UnitDto',
+        },
+        type: 'array',
+        minItems: 1,
+        title: 'Pay-Per-Use Units',
+        description: 'Optional metering units for pay-per-use billing.',
+        example: [
+          {
+            id: 'requests',
+            unitDescription: 'API request',
+            intervalDescription: 'Per month',
+          },
         ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'PASSWORD' for this DTO."
       },
-      "value": {
-        "type": "string",
-        "title": "Value",
-        "description": "Password value.",
-        "format": "password"
-      },
-      "minLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Minimum Length",
-        "description": "Minimum allowed length."
-      },
-      "maxLength": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Maximum Length",
-        "description": "Maximum allowed length."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
+      responseDataFieldNames: {
+        title: 'Response Data Field Names',
+        description: 'Mapping of field names used in provider responses.',
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
+        example: {
+          external_id: 'id',
+          status_text: 'status',
         },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
       },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
+      supportedActions: {
+        items: {
+          $ref: '#/components/schemas/ProductActionsEnum',
+        },
+        type: 'array',
+        minLength: 1,
+        title: 'Supported Actions',
+        description: 'Actions supported by this integration.',
       },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
+      title: {
+        minLength: 1,
+        type: 'string',
+        title: 'Title',
+        description: 'Integration display title.',
+        example: 'Example Product',
+      },
+      logo: {
+        format: 'uri',
+        type: 'string',
+        title: 'Logo URL',
+        description: 'Public HTTPS URL for the integration logo.',
+        example: 'https://cdn.example.com/logo.png',
+      },
+      description: {
+        type: 'string',
+        title: 'Description',
+        description: 'Short description of the integration.',
+        example: 'An example product integration.',
+      },
+      supportedLanguages: {
+        items: {
+          $ref: '#/components/schemas/LanguageEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Supported Languages',
+        description: 'Locales supported by the integration.',
+        example: ['EN'],
+      },
+      listenEvents: {
+        items: {
+          $ref: '#/components/schemas/EventsEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Listen Events',
+        description: 'Platform events the integration can subscribe to.',
+      },
+      requiredRoles: {
+        items: {
+          $ref: '#/components/schemas/RolesEnum',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Required Roles',
+        description: 'Roles required for this integration to operate.',
+      },
+      adminPanel: {
+        $ref: '#/components/schemas/AdminPanelDto',
+      },
+      clientPanel: {
+        $ref: '#/components/schemas/ClientPanelDto',
+      },
+      onboardingUrl: {
+        format: 'uri',
+        type: 'string',
+        title: 'Onboarding URL',
+        description: 'URL to onboard/configure the integration.',
+        example: 'https://example.com/onboarding',
+      },
+      setupAttributes: {
+        items: {
+          $ref: '#/components/schemas/AnyFieldDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Setup Attributes',
+        description:
+          'Configurable attributes that are used in the setup process. Each item is a concrete field DTO discriminated by its `type` literal.',
+      },
     },
-    "type": "object",
-    "required": [
-      "type",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
+    type: 'object',
+    required: ['supportedActions', 'title', 'supportedLanguages'],
   },
-  "FieldOptionDto": {
-    "properties": {
-      "key": {
-        "type": "string",
-        "title": "Key",
-        "description": "Internal key for the option."
+  ProxyActionTaskDto: {
+    properties: {
+      outboxId: {
+        pattern: '^[0-9a-fA-F]{24}$',
+        type: 'string',
+        title: 'Outbox Id',
+        description: "The core's outbox row this task delivers.",
       },
-      "value": {
-        "type": "string",
-        "title": "Value",
-        "description": "Display value for the option."
+      integrationUrl: {
+        format: 'url',
+        type: 'string',
+        title: 'Integration URL',
+        description: 'Absolute URL the proxy calls, action included.',
       },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the option is disabled.",
-        "default": false
-      }
+      integrationToken: {
+        minLength: 1,
+        type: 'string',
+        title: 'Integration Token',
+        description: 'Bearer for the onward call to the integration.',
+      },
+      hookUrl: {
+        format: 'url',
+        type: 'string',
+        title: 'Hook URL',
+        description: "The core's proxy hook for this action.",
+      },
+      deadLetterQueue: {
+        minLength: 1,
+        type: 'string',
+        title: 'Dead Letter Queue',
+        description: 'Topic for a task that exhausted its retries.',
+      },
+      payload: {
+        type: 'object',
+        title: 'Payload',
+        description: 'The integration request, forwarded untouched.',
+      },
     },
-    "type": "object",
-    "required": [
-      "key",
-      "value"
-    ]
-  },
-  "SelectFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "SELECT"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'SELECT' for this DTO."
-      },
-      "options": {
-        "items": {
-          "$ref": "#/components/schemas/FieldOptionDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Options",
-        "description": "The options the user can choose from."
-      },
-      "value": {
-        "$ref": "#/components/schemas/FieldOptionDto"
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "options",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "MultiSelectFieldDto": {
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "MULTI_SELECT"
-        ],
-        "title": "Field Type",
-        "description": "Discriminator literal — always 'MULTI_SELECT' for this DTO."
-      },
-      "options": {
-        "items": {
-          "$ref": "#/components/schemas/FieldOptionDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Options",
-        "description": "The options the user can choose from."
-      },
-      "minSelections": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Minimum Selections",
-        "description": "Minimum number of options that must be selected."
-      },
-      "maxSelections": {
-        "minimum": 0,
-        "type": "integer",
-        "title": "Maximum Selections",
-        "description": "Maximum number of options that may be selected."
-      },
-      "value": {
-        "items": {
-          "$ref": "#/components/schemas/FieldOptionDto"
-        },
-        "type": "array",
-        "title": "Value",
-        "description": "Array of selected options."
-      },
-      "id": {
-        "type": "string",
-        "title": "ID",
-        "description": "Unique identifier for the field."
-      },
-      "label": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Label",
-        "description": "Multilingual label for the field."
-      },
-      "required": {
-        "type": "boolean",
-        "title": "Required",
-        "description": "Whether the field is required."
-      },
-      "disabled": {
-        "type": "boolean",
-        "title": "Disabled",
-        "description": "Whether the field is disabled."
-      },
-      "hidden": {
-        "type": "boolean",
-        "title": "Hidden",
-        "description": "Whether the field is hidden."
-      },
-      "triggersRemoteValidation": {
-        "type": "boolean",
-        "title": "Triggers Remote Validation",
-        "description": "Whether remote validation should be triggered for this field."
-      },
-      "remoteValidationErrorMessage": {
-        "items": {
-          "$ref": "#/components/schemas/MultilangTextDto"
-        },
-        "minItems": 1,
-        "type": "array",
-        "title": "Remote Validation Error Message",
-        "description": "Localized error message shown when remote validation fails."
-      },
-      "upgradable": {
-        "type": "boolean",
-        "title": "Upgradable",
-        "description": "Whether the item attribute is upgradable by the user.",
-        "default": false
-      },
-      "downgradable": {
-        "type": "boolean",
-        "title": "Downgradable",
-        "description": "Whether the item attribute is downgradable by the user.",
-        "default": false
-      }
-    },
-    "type": "object",
-    "required": [
-      "type",
-      "options",
-      "id",
-      "label",
-      "required",
-      "disabled"
-    ]
-  },
-  "EventsEnum": {
-    "type": "string",
-    "enum": [
-      "user/created",
-      "user/updated",
-      "user/deleted",
-      "user/banned",
-      "user/unbanned",
-      "user/company/access/added",
-      "user/company/access/removed",
-      "user/locked",
-      "user/credit-balance/updated",
-      "user/unlocked",
-      "user/password/updated",
-      "user/email/updated",
-      "user/currency/updated",
-      "user/invoice-contact/updated",
-      "user/policy/updated",
-      "user/languages/updated",
-      "user/custom-price-policies/updated",
-      "user/custom-addon-price-policies/updated",
-      "user/custom-affiliate/added",
-      "user/custom-affiliate/removed",
-      "user/invoice-interval/updated",
-      "user/additional-notification-email/removed",
-      "user/additional-notification-email/added",
-      "user/comment/added",
-      "user/comment/removed",
-      "user/comment/updated",
-      "user/tags/updated",
-      "user/setting/added",
-      "user/setting/removed",
-      "user/setting/updated",
-      "user/start-selling",
-      "user/roles/updated",
-      "user/roles/added",
-      "user/roles/deleted",
-      "message/created",
-      "message/updated",
-      "message/deleted",
-      "notification/sent",
-      "policy/created",
-      "policy/updated",
-      "policy/deleted",
-      "product-category/created",
-      "product-category/updated",
-      "product-category/deleted",
-      "invoice-contact/created",
-      "invoice-contact/updated",
-      "invoice-contact/deleted",
-      "invoice/created",
-      "invoice/updated",
-      "invoice/deleted",
-      "currency/created",
-      "currency/updated",
-      "currency/deleted",
-      "affiliate/created",
-      "affiliate/updated",
-      "affiliate/deleted",
-      "company/created",
-      "company/updated",
-      "company/deleted",
-      "organization/integration/attached",
-      "organization/integration/detached",
-      "tld/created",
-      "tld/updated",
-      "tld/deleted",
-      "integration/created",
-      "integration/updated",
-      "integration/deleted",
-      "integration/installed",
-      "integration/uninstalled",
-      "integration/activated",
-      "integration/deactivated",
-      "integration/maintenance-started",
-      "integration/maintenance-finished",
-      "domain-contact/created",
-      "domain-contact/updated",
-      "domain-contact/deleted",
-      "domain-category/created",
-      "domain-category/updated",
-      "domain-category/deleted",
-      "addon/created",
-      "addon/updated",
-      "addon/deleted",
-      "transaction/created",
-      "transaction/canceled",
-      "transaction/failed",
-      "transaction/subscribed",
-      "transaction/unsubscribed",
-      "transaction/updated",
-      "transaction/deleted",
-      "transaction/completed",
-      "transaction/refunded",
-      "template/created",
-      "template/updated",
-      "template/deleted",
-      "coupon/created",
-      "coupon/updated",
-      "coupon/deleted",
-      "template-integration/created",
-      "template-integration/updated",
-      "template-integration/deleted",
-      "order/created",
-      "order/status/in-progress",
-      "order/status/completed",
-      "order/status/canceled",
-      "order/status/pending",
-      "order/status/archived",
-      "order/insufficient-balance",
-      "order/item-detached",
-      "order/invoice-contact-changed",
-      "order/updated",
-      "order/deleted",
-      "setting/created",
-      "setting/updated",
-      "setting/deleted",
-      "issue/created",
-      "issue/updated",
-      "issue/deleted",
-      "task/created",
-      "task/updated",
-      "task/deleted",
-      "task/canceled",
-      "task/in-progress",
-      "task/completed",
-      "task/percentage/updated",
-      "product/created",
-      "product/updated",
-      "product/deleted",
-      "product/auto-renew/updated",
-      "product/enabled",
-      "product/disabled",
-      "product/version-created",
-      "ip-group/created",
-      "ip-group/updated",
-      "ip-group/deleted",
-      "ip/created",
-      "ip/updated",
-      "ip/deleted",
-      "domain-name/created",
-      "domain-name/updated",
-      "domain-name/deleted",
-      "domain-name/locked",
-      "domain-name/unlocked",
-      "domain-name/idshield-activated",
-      "domain-name/idshield-deactivated",
-      "domain-name/bundle-added",
-      "domain-name/bundle-removed",
-      "domain-name/registrant-updated",
-      "domain-name/admin-updated",
-      "domain-name/tech-updated",
-      "domain-name/billing-updated",
-      "domain-name/additional-updated",
-      "item/created",
-      "item/updated",
-      "item/deleted",
-      "item/renewed",
-      "item/upgraded",
-      "item/downgraded",
-      "item/ip-attached",
-      "item/ip-detached",
-      "item/detached-from-order",
-      "item/postponed",
-      "item/transferred-in",
-      "item/canceled",
-      "item/suspended",
-      "item/unsuspended",
-      "item/affiliate/added",
-      "item/bundle/attached",
-      "item/bundle/detached",
-      "item/activated",
-      "item/set-inactive",
-      "item/processed",
-      "item/refund-requested",
-      "item/refund-accepted",
-      "item/refund-rejected",
-      "order/paid",
-      "test",
-      "dead-lettering",
-      "core-queue"
-    ]
-  },
-  "RolesEnum": {
-    "type": "string",
-    "enum": [
-      "FULL_ACCESS",
-      "ORDER_READ",
-      "ORDER_WRITE",
-      "ADDON_READ",
-      "ADDON_WRITE",
-      "AFFILIATE_READ",
-      "AFFILIATE_WRITE",
-      "COMPANY_READ",
-      "COMPANY_WRITE",
-      "TEMPLATE_READ",
-      "TEMPLATE_WRITE",
-      "COUPON_READ",
-      "COUPON_WRITE",
-      "DOMAIN_CATEGORY_READ",
-      "DOMAIN_CATEGORY_WRITE",
-      "DOMAIN_CONTACT_READ",
-      "DOMAIN_CONTACT_WRITE",
-      "DOMAIN_NAME_READ",
-      "DOMAIN_NAME_WRITE",
-      "INVOICE_CONTACT_READ",
-      "INVOICE_CONTACT_WRITE",
-      "INVOICE_READ",
-      "INVOICE_WRITE",
-      "IP_GROUPS_READ",
-      "IP_GROUPS_WRITE",
-      "IPS_READ",
-      "IPS_WRITE",
-      "ITEMS_READ",
-      "ITEMS_WRITE",
-      "ITEM_REFUND",
-      "ORDERS_READ",
-      "ORDERS_WRITE",
-      "TRANSACTIONS_READ",
-      "TRANSACTIONS_WRITE",
-      "POLICIES_READ",
-      "POLICIES_WRITE",
-      "PRODUCT_CATEGORIES_READ",
-      "PRODUCT_CATEGORIES_WRITE",
-      "PRODUCTS_READ",
-      "PRODUCTS_WRITE",
-      "SETTINGS_READ",
-      "SETTINGS_WRITE",
-      "INTEGRATIONS_READ",
-      "INTEGRATIONS_WRITE",
-      "TAG_READ",
-      "TAG_WRITE",
-      "TLDS_READ",
-      "TLDS_WRITE",
-      "USERS_READ",
-      "USERS_WRITE",
-      "ISSUES_WRITE",
-      "ISSUES_READ",
-      "ACTION_LOGS_READ"
-    ]
-  },
-  "LanguageEnum": {
-    "type": "string",
-    "enum": [
-      "AB",
-      "AA",
-      "AF",
-      "AK",
-      "SQ",
-      "AM",
-      "AR",
-      "AN",
-      "HY",
-      "AS",
-      "AV",
-      "AE",
-      "AY",
-      "AZ",
-      "BM",
-      "BA",
-      "EU",
-      "BE",
-      "BN",
-      "BI",
-      "BS",
-      "BR",
-      "BG",
-      "MY",
-      "CA",
-      "KM",
-      "CH",
-      "CE",
-      "NY",
-      "ZH",
-      "CU",
-      "CV",
-      "KW",
-      "CO",
-      "CR",
-      "HR",
-      "CS",
-      "DA",
-      "DV",
-      "NL",
-      "DZ",
-      "EN",
-      "EO",
-      "ET",
-      "EE",
-      "FO",
-      "FJ",
-      "FI",
-      "FR",
-      "FF",
-      "GL",
-      "LG",
-      "KA",
-      "DE",
-      "EL",
-      "GN",
-      "GU",
-      "HT",
-      "HA",
-      "HE",
-      "HZ",
-      "HI",
-      "HO",
-      "HU",
-      "IS",
-      "IO",
-      "IG",
-      "ID",
-      "IA",
-      "IE",
-      "IU",
-      "IK",
-      "GA",
-      "IT",
-      "JA",
-      "JV",
-      "KL",
-      "KN",
-      "KR",
-      "KS",
-      "KK",
-      "KI",
-      "RW",
-      "KY",
-      "KV",
-      "KG",
-      "KO",
-      "KJ",
-      "KU",
-      "LO",
-      "LA",
-      "LV",
-      "LI",
-      "LN",
-      "LT",
-      "LU",
-      "LB",
-      "MK",
-      "MG",
-      "MS",
-      "ML",
-      "MT",
-      "GV",
-      "MI",
-      "MR",
-      "MH",
-      "MN",
-      "NA",
-      "NV",
-      "ND",
-      "NR",
-      "NG",
-      "NE",
-      "SE",
-      "NO",
-      "NB",
-      "NN",
-      "II",
-      "OC",
-      "OJ",
-      "OR",
-      "OM",
-      "OS",
-      "PI",
-      "PS",
-      "FA",
-      "PL",
-      "PT",
-      "PA",
-      "QU",
-      "RO",
-      "RM",
-      "RN",
-      "RU",
-      "SM",
-      "SG",
-      "SA",
-      "SC",
-      "GD",
-      "SR",
-      "SN",
-      "II",
-      "SD",
-      "SI",
-      "SK",
-      "SL",
-      "SO",
-      "ST",
-      "ES",
-      "SU",
-      "SW",
-      "SS",
-      "SV",
-      "TL",
-      "TY",
-      "TG",
-      "TA",
-      "TT",
-      "TE",
-      "TH",
-      "BO",
-      "TI",
-      "TO",
-      "TS",
-      "TN",
-      "TR",
-      "TK",
-      "TW",
-      "UG",
-      "UK",
-      "UR",
-      "UZ",
-      "VE",
-      "VI",
-      "VO",
-      "WA",
-      "CY",
-      "FY",
-      "WO",
-      "XH",
-      "YI",
-      "YO",
-      "ZA",
-      "ZU"
-    ]
-  },
-  "CountryEnum": {
-    "type": "string",
-    "enum": [
-      "AF",
-      "AX",
-      "AL",
-      "DZ",
-      "AS",
-      "AD",
-      "AO",
-      "AI",
-      "AQ",
-      "AG",
-      "AR",
-      "AM",
-      "AW",
-      "AU",
-      "AT",
-      "AZ",
-      "BS",
-      "BH",
-      "BD",
-      "BB",
-      "BY",
-      "BE",
-      "BZ",
-      "BJ",
-      "BM",
-      "BT",
-      "BO",
-      "BQ",
-      "BA",
-      "BW",
-      "BV",
-      "BR",
-      "IO",
-      "BN",
-      "BG",
-      "BF",
-      "BI",
-      "KH",
-      "CM",
-      "CA",
-      "CV",
-      "KY",
-      "CF",
-      "TD",
-      "CL",
-      "CN",
-      "CX",
-      "CC",
-      "CO",
-      "KM",
-      "CG",
-      "CD",
-      "CK",
-      "CR",
-      "CI",
-      "HR",
-      "CU",
-      "CW",
-      "CY",
-      "CZ",
-      "DK",
-      "DJ",
-      "DM",
-      "DO",
-      "EC",
-      "EG",
-      "SV",
-      "GQ",
-      "ER",
-      "EE",
-      "ET",
-      "FK",
-      "FO",
-      "FJ",
-      "FI",
-      "FR",
-      "GF",
-      "PF",
-      "TF",
-      "GA",
-      "GM",
-      "GE",
-      "DE",
-      "GH",
-      "GI",
-      "GR",
-      "GL",
-      "GD",
-      "GP",
-      "GU",
-      "GT",
-      "GG",
-      "GN",
-      "GW",
-      "GY",
-      "HT",
-      "HM",
-      "VA",
-      "HN",
-      "HK",
-      "HU",
-      "IS",
-      "IN",
-      "ID",
-      "IR",
-      "IQ",
-      "IE",
-      "IM",
-      "IL",
-      "IT",
-      "JM",
-      "JP",
-      "JE",
-      "JO",
-      "KZ",
-      "KE",
-      "KI",
-      "KP",
-      "KR",
-      "KW",
-      "KG",
-      "LA",
-      "LV",
-      "LB",
-      "LS",
-      "LR",
-      "LY",
-      "LI",
-      "LT",
-      "LU",
-      "MO",
-      "MK",
-      "MG",
-      "MW",
-      "MY",
-      "MV",
-      "ML",
-      "MT",
-      "MH",
-      "MQ",
-      "MR",
-      "MU",
-      "TN",
-      "TR",
-      "TM",
-      "TC",
-      "TV",
-      "UG",
-      "UA",
-      "AE",
-      "GB",
-      "US",
-      "UM",
-      "UY",
-      "UZ",
-      "VU",
-      "VE",
-      "VN",
-      "VG",
-      "VI",
-      "WF",
-      "EH",
-      "YE",
-      "ZM",
-      "ZW",
-      "YT",
-      "MX",
-      "FM",
-      "MD",
-      "MC",
-      "MN",
-      "ME",
-      "MS",
-      "MA",
-      "MZ",
-      "MM",
-      "NA",
-      "NR",
-      "NP",
-      "NL",
-      "NC",
-      "NZ",
-      "NI",
-      "NE",
-      "NG",
-      "NU",
-      "NF",
-      "MP",
-      "NO",
-      "OM",
-      "PK",
-      "PW",
-      "PS",
-      "PA",
-      "PG",
-      "PY",
-      "PE",
-      "PH",
-      "PN",
-      "PL",
-      "PT",
-      "PR",
-      "QA",
-      "RE",
-      "RO",
-      "RU",
-      "RW",
-      "BL",
-      "SH",
-      "KN",
-      "LC",
-      "MF",
-      "PM",
-      "VC",
-      "WS",
-      "SM",
-      "ST",
-      "SA",
-      "SN",
-      "RS",
-      "SC",
-      "SL",
-      "SG",
-      "SX",
-      "SK",
-      "SI",
-      "SB",
-      "SO",
-      "ZA",
-      "GS",
-      "SS",
-      "ES",
-      "LK",
-      "SD",
-      "SR",
-      "SJ",
-      "SZ",
-      "SE",
-      "CH",
-      "SY",
-      "TW",
-      "TJ",
-      "TZ",
-      "TH",
-      "TL",
-      "TG",
-      "TK",
-      "TO",
-      "TT"
-    ]
-  },
-  "CurrencyEnum": {
-    "type": "string",
-    "enum": [
-      "EUR",
-      "USD",
-      "GBP",
-      "CHF",
-      "SEK",
-      "NOK",
-      "DKK",
-      "PLN",
-      "CZK",
-      "HUF",
-      "RON",
-      "BGN",
-      "TRY",
-      "RUB",
-      "JPY",
-      "CNY",
-      "AUD",
-      "NZD",
-      "CAD",
-      "ZAR",
-      "INR",
-      "MXN",
-      "BRL",
-      "ARS",
-      "CLP",
-      "COP",
-      "PEN",
-      "UYU",
-      "VES",
-      "ILS",
-      "AED",
-      "SAR",
-      "KRW",
-      "SGD",
-      "HKD",
-      "TWD",
-      "THB",
-      "MYR",
-      "IDR",
-      "PHP",
-      "VND",
-      "AFN",
-      "ALL",
-      "AMD",
-      "AOA",
-      "AWG",
-      "AZN",
-      "BAM",
-      "BBD",
-      "BDT",
-      "BHD",
-      "BIF",
-      "BMD",
-      "BND",
-      "BOB",
-      "BSD",
-      "BTN",
-      "BWP",
-      "BYN",
-      "BZD",
-      "CDF",
-      "CRC",
-      "CUP",
-      "CVE",
-      "DJF",
-      "DOP",
-      "DZD",
-      "EGP",
-      "ERN",
-      "ETB",
-      "FJD",
-      "GEL",
-      "GHS",
-      "GMD",
-      "GNF",
-      "GTQ",
-      "GYD",
-      "HNL",
-      "HTG",
-      "IQD",
-      "IRR",
-      "ISK",
-      "JMD",
-      "JOD",
-      "KES",
-      "KGS",
-      "KHR",
-      "KMF",
-      "KWD",
-      "KYD",
-      "KZT",
-      "LAK",
-      "LBP",
-      "LKR",
-      "LRD",
-      "LSL",
-      "LYD",
-      "MAD",
-      "MDL",
-      "MGA",
-      "MKD",
-      "MMK",
-      "MNT",
-      "MOP",
-      "MUR",
-      "MVR",
-      "MWK",
-      "MZN",
-      "NAD",
-      "NGN",
-      "NIO",
-      "NPR",
-      "OMR",
-      "PAB",
-      "PGK",
-      "PKR",
-      "PYG",
-      "QAR",
-      "RSD",
-      "RWF",
-      "SBD",
-      "SDG",
-      "SLE",
-      "SOS",
-      "SRD",
-      "SSP",
-      "STN",
-      "SYP",
-      "SZL",
-      "TJS",
-      "TMT",
-      "TND",
-      "TOP",
-      "TTD",
-      "TZS",
-      "UAH",
-      "UGX",
-      "UZS",
-      "VED",
-      "VUV",
-      "WST",
-      "XAF",
-      "XCD",
-      "XCG",
-      "XOF",
-      "XPF",
-      "YER",
-      "ZMW",
-      "ZWG"
-    ]
-  },
-  "FieldTypeEnum": {
-    "type": "string",
-    "enum": [
-      "BOOLEAN",
-      "TEXT",
-      "TEXTAREA",
-      "NUMBER",
-      "PHONE",
-      "EMAIL",
-      "URL",
-      "COUNTRIES",
-      "CURRENCY",
-      "DATE",
-      "PASSWORD",
-      "SELECT",
-      "MULTI_SELECT"
-    ]
-  },
-  "ProductActionsEnum": {
-    "type": "string",
-    "enum": [
-      "CREATE",
-      "RENEW",
-      "UPGRADE",
-      "DOWNGRADE",
-      "TRANSFER",
-      "TRADE",
-      "SUSPEND",
-      "UNSUSPEND",
-      "DELETE"
-    ]
-  },
-  "OpenMethodEnum": {
-    "type": "string",
-    "enum": [
-      "ajax_call",
-      "small_iframe",
-      "medium_iframe",
-      "large_iframe"
-    ]
-  },
-  "NotificationMessageTypeEnum": {
-    "type": "string",
-    "enum": [
-      "email",
-      "sms",
-      "push"
-    ]
-  },
-  "AnyFieldDto": {
-    "title": "AnyFieldDto",
-    "description": "Discriminated union of every concrete field DTO. Discriminator is the string-literal `type` property.",
-    "oneOf": [
-      {
-        "$ref": "#/components/schemas/BooleanFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/TextFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/TextareaFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/NumberFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/PhoneFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/EmailFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/UrlFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/CountriesFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/CurrencyFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/DateFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/PasswordFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/SelectFieldDto"
-      },
-      {
-        "$ref": "#/components/schemas/MultiSelectFieldDto"
-      }
+    type: 'object',
+    required: [
+      'outboxId',
+      'integrationUrl',
+      'integrationToken',
+      'hookUrl',
+      'deadLetterQueue',
+      'payload',
     ],
-    "discriminator": {
-      "propertyName": "type",
-      "mapping": {
-        "BOOLEAN": "#/components/schemas/BooleanFieldDto",
-        "TEXT": "#/components/schemas/TextFieldDto",
-        "TEXTAREA": "#/components/schemas/TextareaFieldDto",
-        "NUMBER": "#/components/schemas/NumberFieldDto",
-        "PHONE": "#/components/schemas/PhoneFieldDto",
-        "EMAIL": "#/components/schemas/EmailFieldDto",
-        "URL": "#/components/schemas/UrlFieldDto",
-        "COUNTRIES": "#/components/schemas/CountriesFieldDto",
-        "CURRENCY": "#/components/schemas/CurrencyFieldDto",
-        "DATE": "#/components/schemas/DateFieldDto",
-        "PASSWORD": "#/components/schemas/PasswordFieldDto",
-        "SELECT": "#/components/schemas/SelectFieldDto",
-        "MULTI_SELECT": "#/components/schemas/MultiSelectFieldDto"
-      }
-    }
-  }
+  },
+  MultilangTextDto: {
+    properties: {
+      language: {
+        $ref: '#/components/schemas/LanguageEnum',
+      },
+      text: {
+        minLength: 1,
+        type: 'string',
+        title: 'Text',
+        description: 'The text content in the specified language.',
+      },
+    },
+    type: 'object',
+    required: ['language', 'text'],
+  },
+  BaseFieldDto: {
+    properties: {
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['id', 'label', 'required', 'disabled'],
+  },
+  BooleanFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['BOOLEAN'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'BOOLEAN' for this DTO.",
+      },
+      value: {
+        type: 'boolean',
+        title: 'Value',
+        description: 'Boolean value of the field.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  TextFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['TEXT'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'TEXT' for this DTO.",
+      },
+      value: {
+        type: 'string',
+        title: 'Value',
+        description: 'Text value of the field.',
+      },
+      minLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Minimum Length',
+        description: 'Minimum allowed character length.',
+      },
+      maxLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Maximum Length',
+        description: 'Maximum allowed character length.',
+      },
+      regexValidation: {
+        type: 'string',
+        title: 'Regex Validation',
+        description: 'Optional regex to validate input.',
+        example: '^[A-Za-z0-9_-]+$',
+      },
+      regexValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Regex Validation Error Message',
+        description:
+          'Localized error message shown when regex validation fails.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  TextareaFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['TEXTAREA'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'TEXTAREA' for this DTO.",
+      },
+      value: {
+        type: 'string',
+        title: 'Value',
+        description: 'Text value of the field.',
+      },
+      minLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Minimum Length',
+        description: 'Minimum allowed character length.',
+      },
+      maxLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Maximum Length',
+        description: 'Maximum allowed character length.',
+      },
+      regexValidation: {
+        type: 'string',
+        title: 'Regex Validation',
+        description: 'Optional regex to validate input.',
+        example: '^[A-Za-z0-9_-]+$',
+      },
+      regexValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Regex Validation Error Message',
+        description:
+          'Localized error message shown when regex validation fails.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  NumberFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['NUMBER'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'NUMBER' for this DTO.",
+      },
+      value: {
+        type: 'number',
+        title: 'Value',
+        description: 'Numeric value of the field.',
+      },
+      min: {
+        type: 'number',
+        title: 'Minimum',
+        description: 'Minimum allowed value.',
+      },
+      max: {
+        type: 'number',
+        title: 'Maximum',
+        description: 'Maximum allowed value.',
+      },
+      integer: {
+        type: 'boolean',
+        title: 'Integer Only',
+        description: 'When true, only integer values are allowed.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  PhoneFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['PHONE'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'PHONE' for this DTO.",
+      },
+      value: {
+        type: 'string',
+        title: 'Value',
+        description: 'Phone number in E.164 format (e.g. +14155552671).',
+        example: '+14155552671',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  EmailFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['EMAIL'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'EMAIL' for this DTO.",
+      },
+      value: {
+        format: 'email',
+        type: 'string',
+        title: 'Value',
+        description: 'Email address.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  UrlFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['URL'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'URL' for this DTO.",
+      },
+      value: {
+        format: 'uri',
+        type: 'string',
+        title: 'Value',
+        description: 'URL.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  CountriesFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['COUNTRIES'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'COUNTRIES' for this DTO.",
+      },
+      value: {
+        items: {
+          $ref: '#/components/schemas/CountryEnum',
+        },
+        type: 'array',
+        title: 'Value',
+        description: 'Array of ISO 3166-1 alpha-2 country codes.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  CurrencyFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['CURRENCY'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'CURRENCY' for this DTO.",
+      },
+      value: {
+        $ref: '#/components/schemas/CurrencyEnum',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  DateFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['DATE'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'DATE' for this DTO.",
+      },
+      value: {
+        oneOf: [
+          {
+            format: 'date',
+            type: 'string',
+          },
+          {
+            format: 'date-time',
+            type: 'string',
+          },
+        ],
+        title: 'Value',
+        description: 'ISO 8601 date or date-time string.',
+        type: 'string',
+        format: 'date-time',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  PasswordFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['PASSWORD'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'PASSWORD' for this DTO.",
+      },
+      value: {
+        type: 'string',
+        title: 'Value',
+        description: 'Password value.',
+        format: 'password',
+      },
+      minLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Minimum Length',
+        description: 'Minimum allowed length.',
+      },
+      maxLength: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Maximum Length',
+        description: 'Maximum allowed length.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'id', 'label', 'required', 'disabled'],
+  },
+  FieldOptionDto: {
+    properties: {
+      key: {
+        type: 'string',
+        title: 'Key',
+        description: 'Internal key for the option.',
+      },
+      value: {
+        type: 'string',
+        title: 'Value',
+        description: 'Display value for the option.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the option is disabled.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['key', 'value'],
+  },
+  SelectFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['SELECT'],
+        title: 'Field Type',
+        description: "Discriminator literal — always 'SELECT' for this DTO.",
+      },
+      options: {
+        items: {
+          $ref: '#/components/schemas/FieldOptionDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Options',
+        description: 'The options the user can choose from.',
+      },
+      value: {
+        $ref: '#/components/schemas/FieldOptionDto',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'options', 'id', 'label', 'required', 'disabled'],
+  },
+  MultiSelectFieldDto: {
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['MULTI_SELECT'],
+        title: 'Field Type',
+        description:
+          "Discriminator literal — always 'MULTI_SELECT' for this DTO.",
+      },
+      options: {
+        items: {
+          $ref: '#/components/schemas/FieldOptionDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Options',
+        description: 'The options the user can choose from.',
+      },
+      minSelections: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Minimum Selections',
+        description: 'Minimum number of options that must be selected.',
+      },
+      maxSelections: {
+        minimum: 0,
+        type: 'integer',
+        title: 'Maximum Selections',
+        description: 'Maximum number of options that may be selected.',
+      },
+      value: {
+        items: {
+          $ref: '#/components/schemas/FieldOptionDto',
+        },
+        type: 'array',
+        title: 'Value',
+        description: 'Array of selected options.',
+      },
+      id: {
+        type: 'string',
+        title: 'ID',
+        description: 'Unique identifier for the field.',
+      },
+      label: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Label',
+        description: 'Multilingual label for the field.',
+      },
+      required: {
+        type: 'boolean',
+        title: 'Required',
+        description: 'Whether the field is required.',
+      },
+      disabled: {
+        type: 'boolean',
+        title: 'Disabled',
+        description: 'Whether the field is disabled.',
+      },
+      hidden: {
+        type: 'boolean',
+        title: 'Hidden',
+        description: 'Whether the field is hidden.',
+      },
+      triggersRemoteValidation: {
+        type: 'boolean',
+        title: 'Triggers Remote Validation',
+        description:
+          'Whether remote validation should be triggered for this field.',
+      },
+      remoteValidationErrorMessage: {
+        items: {
+          $ref: '#/components/schemas/MultilangTextDto',
+        },
+        minItems: 1,
+        type: 'array',
+        title: 'Remote Validation Error Message',
+        description:
+          'Localized error message shown when remote validation fails.',
+      },
+      upgradable: {
+        type: 'boolean',
+        title: 'Upgradable',
+        description: 'Whether the item attribute is upgradable by the user.',
+        default: false,
+      },
+      downgradable: {
+        type: 'boolean',
+        title: 'Downgradable',
+        description: 'Whether the item attribute is downgradable by the user.',
+        default: false,
+      },
+    },
+    type: 'object',
+    required: ['type', 'options', 'id', 'label', 'required', 'disabled'],
+  },
+  EventsEnum: {
+    type: 'string',
+    enum: [
+      'user/created',
+      'user/updated',
+      'user/deleted',
+      'user/banned',
+      'user/unbanned',
+      'user/company/access/added',
+      'user/company/access/removed',
+      'user/locked',
+      'user/credit-balance/updated',
+      'user/unlocked',
+      'user/password/updated',
+      'user/email/updated',
+      'user/currency/updated',
+      'user/invoice-contact/updated',
+      'user/policy/updated',
+      'user/languages/updated',
+      'user/custom-price-policies/updated',
+      'user/custom-addon-price-policies/updated',
+      'user/custom-affiliate/added',
+      'user/custom-affiliate/removed',
+      'user/invoice-interval/updated',
+      'user/additional-notification-email/removed',
+      'user/additional-notification-email/added',
+      'user/comment/added',
+      'user/comment/removed',
+      'user/comment/updated',
+      'user/tags/updated',
+      'user/setting/added',
+      'user/setting/removed',
+      'user/setting/updated',
+      'user/start-selling',
+      'user/roles/updated',
+      'user/roles/added',
+      'user/roles/deleted',
+      'message/created',
+      'message/updated',
+      'message/deleted',
+      'notification/sent',
+      'policy/created',
+      'policy/updated',
+      'policy/deleted',
+      'product-category/created',
+      'product-category/updated',
+      'product-category/deleted',
+      'invoice-contact/created',
+      'invoice-contact/updated',
+      'invoice-contact/deleted',
+      'invoice/created',
+      'invoice/updated',
+      'invoice/deleted',
+      'currency/created',
+      'currency/updated',
+      'currency/deleted',
+      'affiliate/created',
+      'affiliate/updated',
+      'affiliate/deleted',
+      'company/created',
+      'company/updated',
+      'company/deleted',
+      'organization/integration/attached',
+      'organization/integration/detached',
+      'tld/created',
+      'tld/updated',
+      'tld/deleted',
+      'integration/created',
+      'integration/updated',
+      'integration/deleted',
+      'integration/installed',
+      'integration/uninstalled',
+      'integration/activated',
+      'integration/deactivated',
+      'integration/maintenance-started',
+      'integration/maintenance-finished',
+      'domain-contact/created',
+      'domain-contact/updated',
+      'domain-contact/deleted',
+      'domain-category/created',
+      'domain-category/updated',
+      'domain-category/deleted',
+      'addon/created',
+      'addon/updated',
+      'addon/deleted',
+      'transaction/created',
+      'transaction/canceled',
+      'transaction/failed',
+      'transaction/subscribed',
+      'transaction/unsubscribed',
+      'transaction/updated',
+      'transaction/deleted',
+      'transaction/completed',
+      'transaction/refunded',
+      'template/created',
+      'template/updated',
+      'template/deleted',
+      'coupon/created',
+      'coupon/updated',
+      'coupon/deleted',
+      'template-integration/created',
+      'template-integration/updated',
+      'template-integration/deleted',
+      'order/created',
+      'order/status/in-progress',
+      'order/status/completed',
+      'order/status/canceled',
+      'order/status/pending',
+      'order/status/archived',
+      'order/insufficient-balance',
+      'order/item-detached',
+      'order/invoice-contact-changed',
+      'order/updated',
+      'order/deleted',
+      'setting/created',
+      'setting/updated',
+      'setting/deleted',
+      'issue/created',
+      'issue/updated',
+      'issue/deleted',
+      'task/created',
+      'task/updated',
+      'task/deleted',
+      'task/canceled',
+      'task/in-progress',
+      'task/completed',
+      'task/percentage/updated',
+      'product/created',
+      'product/updated',
+      'product/deleted',
+      'product/auto-renew/updated',
+      'product/enabled',
+      'product/disabled',
+      'product/version-created',
+      'ip-group/created',
+      'ip-group/updated',
+      'ip-group/deleted',
+      'ip/created',
+      'ip/updated',
+      'ip/deleted',
+      'domain-name/created',
+      'domain-name/updated',
+      'domain-name/deleted',
+      'domain-name/locked',
+      'domain-name/unlocked',
+      'domain-name/idshield-activated',
+      'domain-name/idshield-deactivated',
+      'domain-name/bundle-added',
+      'domain-name/bundle-removed',
+      'domain-name/registrant-updated',
+      'domain-name/admin-updated',
+      'domain-name/tech-updated',
+      'domain-name/billing-updated',
+      'domain-name/additional-updated',
+      'item/created',
+      'item/updated',
+      'item/deleted',
+      'item/renewed',
+      'item/upgraded',
+      'item/downgraded',
+      'item/ip-attached',
+      'item/ip-detached',
+      'item/detached-from-order',
+      'item/postponed',
+      'item/transferred-in',
+      'item/canceled',
+      'item/suspended',
+      'item/unsuspended',
+      'item/affiliate/added',
+      'item/bundle/attached',
+      'item/bundle/detached',
+      'item/activated',
+      'item/set-inactive',
+      'item/processed',
+      'item/refund-requested',
+      'item/refund-accepted',
+      'item/refund-rejected',
+      'order/paid',
+      'test',
+      'dead-lettering',
+      'core-queue',
+    ],
+  },
+  RolesEnum: {
+    type: 'string',
+    enum: [
+      'FULL_ACCESS',
+      'ORDER_READ',
+      'ORDER_WRITE',
+      'ADDON_READ',
+      'ADDON_WRITE',
+      'AFFILIATE_READ',
+      'AFFILIATE_WRITE',
+      'COMPANY_READ',
+      'COMPANY_WRITE',
+      'TEMPLATE_READ',
+      'TEMPLATE_WRITE',
+      'COUPON_READ',
+      'COUPON_WRITE',
+      'DOMAIN_CATEGORY_READ',
+      'DOMAIN_CATEGORY_WRITE',
+      'DOMAIN_CONTACT_READ',
+      'DOMAIN_CONTACT_WRITE',
+      'DOMAIN_NAME_READ',
+      'DOMAIN_NAME_WRITE',
+      'INVOICE_CONTACT_READ',
+      'INVOICE_CONTACT_WRITE',
+      'INVOICE_READ',
+      'INVOICE_WRITE',
+      'IP_GROUPS_READ',
+      'IP_GROUPS_WRITE',
+      'IPS_READ',
+      'IPS_WRITE',
+      'ITEMS_READ',
+      'ITEMS_WRITE',
+      'ITEM_REFUND',
+      'ORDERS_READ',
+      'ORDERS_WRITE',
+      'TRANSACTIONS_READ',
+      'TRANSACTIONS_WRITE',
+      'POLICIES_READ',
+      'POLICIES_WRITE',
+      'PRODUCT_CATEGORIES_READ',
+      'PRODUCT_CATEGORIES_WRITE',
+      'PRODUCTS_READ',
+      'PRODUCTS_WRITE',
+      'SETTINGS_READ',
+      'SETTINGS_WRITE',
+      'INTEGRATIONS_READ',
+      'INTEGRATIONS_WRITE',
+      'TAG_READ',
+      'TAG_WRITE',
+      'TLDS_READ',
+      'TLDS_WRITE',
+      'USERS_READ',
+      'USERS_WRITE',
+      'ISSUES_WRITE',
+      'ISSUES_READ',
+      'ACTION_LOGS_READ',
+    ],
+  },
+  LanguageEnum: {
+    type: 'string',
+    enum: [
+      'AB',
+      'AA',
+      'AF',
+      'AK',
+      'SQ',
+      'AM',
+      'AR',
+      'AN',
+      'HY',
+      'AS',
+      'AV',
+      'AE',
+      'AY',
+      'AZ',
+      'BM',
+      'BA',
+      'EU',
+      'BE',
+      'BN',
+      'BI',
+      'BS',
+      'BR',
+      'BG',
+      'MY',
+      'CA',
+      'KM',
+      'CH',
+      'CE',
+      'NY',
+      'ZH',
+      'CU',
+      'CV',
+      'KW',
+      'CO',
+      'CR',
+      'HR',
+      'CS',
+      'DA',
+      'DV',
+      'NL',
+      'DZ',
+      'EN',
+      'EO',
+      'ET',
+      'EE',
+      'FO',
+      'FJ',
+      'FI',
+      'FR',
+      'FF',
+      'GL',
+      'LG',
+      'KA',
+      'DE',
+      'EL',
+      'GN',
+      'GU',
+      'HT',
+      'HA',
+      'HE',
+      'HZ',
+      'HI',
+      'HO',
+      'HU',
+      'IS',
+      'IO',
+      'IG',
+      'ID',
+      'IA',
+      'IE',
+      'IU',
+      'IK',
+      'GA',
+      'IT',
+      'JA',
+      'JV',
+      'KL',
+      'KN',
+      'KR',
+      'KS',
+      'KK',
+      'KI',
+      'RW',
+      'KY',
+      'KV',
+      'KG',
+      'KO',
+      'KJ',
+      'KU',
+      'LO',
+      'LA',
+      'LV',
+      'LI',
+      'LN',
+      'LT',
+      'LU',
+      'LB',
+      'MK',
+      'MG',
+      'MS',
+      'ML',
+      'MT',
+      'GV',
+      'MI',
+      'MR',
+      'MH',
+      'MN',
+      'NA',
+      'NV',
+      'ND',
+      'NR',
+      'NG',
+      'NE',
+      'SE',
+      'NO',
+      'NB',
+      'NN',
+      'II',
+      'OC',
+      'OJ',
+      'OR',
+      'OM',
+      'OS',
+      'PI',
+      'PS',
+      'FA',
+      'PL',
+      'PT',
+      'PA',
+      'QU',
+      'RO',
+      'RM',
+      'RN',
+      'RU',
+      'SM',
+      'SG',
+      'SA',
+      'SC',
+      'GD',
+      'SR',
+      'SN',
+      'II',
+      'SD',
+      'SI',
+      'SK',
+      'SL',
+      'SO',
+      'ST',
+      'ES',
+      'SU',
+      'SW',
+      'SS',
+      'SV',
+      'TL',
+      'TY',
+      'TG',
+      'TA',
+      'TT',
+      'TE',
+      'TH',
+      'BO',
+      'TI',
+      'TO',
+      'TS',
+      'TN',
+      'TR',
+      'TK',
+      'TW',
+      'UG',
+      'UK',
+      'UR',
+      'UZ',
+      'VE',
+      'VI',
+      'VO',
+      'WA',
+      'CY',
+      'FY',
+      'WO',
+      'XH',
+      'YI',
+      'YO',
+      'ZA',
+      'ZU',
+    ],
+  },
+  CountryEnum: {
+    type: 'string',
+    enum: [
+      'AF',
+      'AX',
+      'AL',
+      'DZ',
+      'AS',
+      'AD',
+      'AO',
+      'AI',
+      'AQ',
+      'AG',
+      'AR',
+      'AM',
+      'AW',
+      'AU',
+      'AT',
+      'AZ',
+      'BS',
+      'BH',
+      'BD',
+      'BB',
+      'BY',
+      'BE',
+      'BZ',
+      'BJ',
+      'BM',
+      'BT',
+      'BO',
+      'BQ',
+      'BA',
+      'BW',
+      'BV',
+      'BR',
+      'IO',
+      'BN',
+      'BG',
+      'BF',
+      'BI',
+      'KH',
+      'CM',
+      'CA',
+      'CV',
+      'KY',
+      'CF',
+      'TD',
+      'CL',
+      'CN',
+      'CX',
+      'CC',
+      'CO',
+      'KM',
+      'CG',
+      'CD',
+      'CK',
+      'CR',
+      'CI',
+      'HR',
+      'CU',
+      'CW',
+      'CY',
+      'CZ',
+      'DK',
+      'DJ',
+      'DM',
+      'DO',
+      'EC',
+      'EG',
+      'SV',
+      'GQ',
+      'ER',
+      'EE',
+      'ET',
+      'FK',
+      'FO',
+      'FJ',
+      'FI',
+      'FR',
+      'GF',
+      'PF',
+      'TF',
+      'GA',
+      'GM',
+      'GE',
+      'DE',
+      'GH',
+      'GI',
+      'GR',
+      'GL',
+      'GD',
+      'GP',
+      'GU',
+      'GT',
+      'GG',
+      'GN',
+      'GW',
+      'GY',
+      'HT',
+      'HM',
+      'VA',
+      'HN',
+      'HK',
+      'HU',
+      'IS',
+      'IN',
+      'ID',
+      'IR',
+      'IQ',
+      'IE',
+      'IM',
+      'IL',
+      'IT',
+      'JM',
+      'JP',
+      'JE',
+      'JO',
+      'KZ',
+      'KE',
+      'KI',
+      'KP',
+      'KR',
+      'KW',
+      'KG',
+      'LA',
+      'LV',
+      'LB',
+      'LS',
+      'LR',
+      'LY',
+      'LI',
+      'LT',
+      'LU',
+      'MO',
+      'MK',
+      'MG',
+      'MW',
+      'MY',
+      'MV',
+      'ML',
+      'MT',
+      'MH',
+      'MQ',
+      'MR',
+      'MU',
+      'TN',
+      'TR',
+      'TM',
+      'TC',
+      'TV',
+      'UG',
+      'UA',
+      'AE',
+      'GB',
+      'US',
+      'UM',
+      'UY',
+      'UZ',
+      'VU',
+      'VE',
+      'VN',
+      'VG',
+      'VI',
+      'WF',
+      'EH',
+      'YE',
+      'ZM',
+      'ZW',
+      'YT',
+      'MX',
+      'FM',
+      'MD',
+      'MC',
+      'MN',
+      'ME',
+      'MS',
+      'MA',
+      'MZ',
+      'MM',
+      'NA',
+      'NR',
+      'NP',
+      'NL',
+      'NC',
+      'NZ',
+      'NI',
+      'NE',
+      'NG',
+      'NU',
+      'NF',
+      'MP',
+      'NO',
+      'OM',
+      'PK',
+      'PW',
+      'PS',
+      'PA',
+      'PG',
+      'PY',
+      'PE',
+      'PH',
+      'PN',
+      'PL',
+      'PT',
+      'PR',
+      'QA',
+      'RE',
+      'RO',
+      'RU',
+      'RW',
+      'BL',
+      'SH',
+      'KN',
+      'LC',
+      'MF',
+      'PM',
+      'VC',
+      'WS',
+      'SM',
+      'ST',
+      'SA',
+      'SN',
+      'RS',
+      'SC',
+      'SL',
+      'SG',
+      'SX',
+      'SK',
+      'SI',
+      'SB',
+      'SO',
+      'ZA',
+      'GS',
+      'SS',
+      'ES',
+      'LK',
+      'SD',
+      'SR',
+      'SJ',
+      'SZ',
+      'SE',
+      'CH',
+      'SY',
+      'TW',
+      'TJ',
+      'TZ',
+      'TH',
+      'TL',
+      'TG',
+      'TK',
+      'TO',
+      'TT',
+    ],
+  },
+  CurrencyEnum: {
+    type: 'string',
+    enum: [
+      'EUR',
+      'USD',
+      'GBP',
+      'CHF',
+      'SEK',
+      'NOK',
+      'DKK',
+      'PLN',
+      'CZK',
+      'HUF',
+      'RON',
+      'BGN',
+      'TRY',
+      'RUB',
+      'JPY',
+      'CNY',
+      'AUD',
+      'NZD',
+      'CAD',
+      'ZAR',
+      'INR',
+      'MXN',
+      'BRL',
+      'ARS',
+      'CLP',
+      'COP',
+      'PEN',
+      'UYU',
+      'VES',
+      'ILS',
+      'AED',
+      'SAR',
+      'KRW',
+      'SGD',
+      'HKD',
+      'TWD',
+      'THB',
+      'MYR',
+      'IDR',
+      'PHP',
+      'VND',
+      'AFN',
+      'ALL',
+      'AMD',
+      'AOA',
+      'AWG',
+      'AZN',
+      'BAM',
+      'BBD',
+      'BDT',
+      'BHD',
+      'BIF',
+      'BMD',
+      'BND',
+      'BOB',
+      'BSD',
+      'BTN',
+      'BWP',
+      'BYN',
+      'BZD',
+      'CDF',
+      'CRC',
+      'CUP',
+      'CVE',
+      'DJF',
+      'DOP',
+      'DZD',
+      'EGP',
+      'ERN',
+      'ETB',
+      'FJD',
+      'GEL',
+      'GHS',
+      'GMD',
+      'GNF',
+      'GTQ',
+      'GYD',
+      'HNL',
+      'HTG',
+      'IQD',
+      'IRR',
+      'ISK',
+      'JMD',
+      'JOD',
+      'KES',
+      'KGS',
+      'KHR',
+      'KMF',
+      'KWD',
+      'KYD',
+      'KZT',
+      'LAK',
+      'LBP',
+      'LKR',
+      'LRD',
+      'LSL',
+      'LYD',
+      'MAD',
+      'MDL',
+      'MGA',
+      'MKD',
+      'MMK',
+      'MNT',
+      'MOP',
+      'MUR',
+      'MVR',
+      'MWK',
+      'MZN',
+      'NAD',
+      'NGN',
+      'NIO',
+      'NPR',
+      'OMR',
+      'PAB',
+      'PGK',
+      'PKR',
+      'PYG',
+      'QAR',
+      'RSD',
+      'RWF',
+      'SBD',
+      'SDG',
+      'SLE',
+      'SOS',
+      'SRD',
+      'SSP',
+      'STN',
+      'SYP',
+      'SZL',
+      'TJS',
+      'TMT',
+      'TND',
+      'TOP',
+      'TTD',
+      'TZS',
+      'UAH',
+      'UGX',
+      'UZS',
+      'VED',
+      'VUV',
+      'WST',
+      'XAF',
+      'XCD',
+      'XCG',
+      'XOF',
+      'XPF',
+      'YER',
+      'ZMW',
+      'ZWG',
+    ],
+  },
+  FieldTypeEnum: {
+    type: 'string',
+    enum: [
+      'BOOLEAN',
+      'TEXT',
+      'TEXTAREA',
+      'NUMBER',
+      'PHONE',
+      'EMAIL',
+      'URL',
+      'COUNTRIES',
+      'CURRENCY',
+      'DATE',
+      'PASSWORD',
+      'SELECT',
+      'MULTI_SELECT',
+    ],
+  },
+  ProductActionsEnum: {
+    type: 'string',
+    enum: [
+      'CREATE',
+      'RENEW',
+      'UPGRADE',
+      'DOWNGRADE',
+      'TRANSFER',
+      'TRADE',
+      'SUSPEND',
+      'UNSUSPEND',
+      'DELETE',
+    ],
+  },
+  OpenMethodEnum: {
+    type: 'string',
+    enum: ['ajax_call', 'small_iframe', 'medium_iframe', 'large_iframe'],
+  },
+  NotificationMessageTypeEnum: {
+    type: 'string',
+    enum: ['email', 'sms', 'push'],
+  },
+  AnyFieldDto: {
+    title: 'AnyFieldDto',
+    description:
+      'Discriminated union of every concrete field DTO. Discriminator is the string-literal `type` property.',
+    oneOf: [
+      {
+        $ref: '#/components/schemas/BooleanFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/TextFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/TextareaFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/NumberFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/PhoneFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/EmailFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/UrlFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/CountriesFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/CurrencyFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/DateFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/PasswordFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/SelectFieldDto',
+      },
+      {
+        $ref: '#/components/schemas/MultiSelectFieldDto',
+      },
+    ],
+    discriminator: {
+      propertyName: 'type',
+      mapping: {
+        BOOLEAN: '#/components/schemas/BooleanFieldDto',
+        TEXT: '#/components/schemas/TextFieldDto',
+        TEXTAREA: '#/components/schemas/TextareaFieldDto',
+        NUMBER: '#/components/schemas/NumberFieldDto',
+        PHONE: '#/components/schemas/PhoneFieldDto',
+        EMAIL: '#/components/schemas/EmailFieldDto',
+        URL: '#/components/schemas/UrlFieldDto',
+        COUNTRIES: '#/components/schemas/CountriesFieldDto',
+        CURRENCY: '#/components/schemas/CurrencyFieldDto',
+        DATE: '#/components/schemas/DateFieldDto',
+        PASSWORD: '#/components/schemas/PasswordFieldDto',
+        SELECT: '#/components/schemas/SelectFieldDto',
+        MULTI_SELECT: '#/components/schemas/MultiSelectFieldDto',
+      },
+    },
+  },
 } as const;

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -40,6 +40,7 @@ import { validationMetadatasToSchemas } from 'class-validator-jsonschema';
 import '../dtos/country.dto';
 import '../dtos/notification/notification-info.dto';
 import '../dtos/product/product-info.dto';
+import '../dtos/proxy-action-task.dto';
 // Concrete field DTOs (split from the deprecated mega FieldDto)
 import '../dtos/fields/boolean-field.dto';
 import '../dtos/fields/text-field.dto';

--- a/validators/credit-note-response-validator.spec.ts
+++ b/validators/credit-note-response-validator.spec.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import { validateCreditNoteResponseDto } from './credit-note-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const ISSUED = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  invoiceUrl: 'https://invoices.example.com/doc-1.pdf',
+  invoiceNumber: 'INV-2026-0001',
+  invoiceId: 'ext-abc-123',
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateCreditNoteResponseDto(body)).map((e) => e.property);
+
+describe('validateCreditNoteResponseDto', () => {
+  it('accepts an issued document', async () => {
+    expect(await messages(ISSUED)).toEqual([]);
+  });
+
+  it.each([ResponseStatusEnum.FAILURE, ResponseStatusEnum.PENDING])(
+    'accepts a %s report without any document fields — there is no document to describe',
+    async (status) => {
+      expect(
+        await messages({
+          code: 200,
+          message: 'not issued',
+          status,
+          outboxId: ISSUED.outboxId,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it('rejects a success without the document fields', async () => {
+    const body = omit(ISSUED, 'invoiceUrl', 'invoiceNumber', 'invoiceId');
+    expect((await messages(body)).sort()).toEqual([
+      'invoiceId',
+      'invoiceNumber',
+      'invoiceUrl',
+    ]);
+  });
+
+  it('rejects a report without status or outboxId — nothing to settle or correlate on', async () => {
+    const body = omit(ISSUED, 'status', 'outboxId', '');
+    expect((await messages(body)).sort()).toEqual(['outboxId', 'status']);
+  });
+
+  it('rejects a status outside the enum and a document url that is not a url', async () => {
+    expect((await messages({ ...ISSUED, status: 'done' })).sort()).toEqual([
+      'status',
+    ]);
+    expect(await messages({ ...ISSUED, invoiceUrl: 'not a url' })).toEqual([
+      'invoiceUrl',
+    ]);
+  });
+});

--- a/validators/credit-note-response-validator.ts
+++ b/validators/credit-note-response-validator.ts
@@ -6,8 +6,8 @@ import { CreditNoteResponseDto } from '../dtos/invoice/responses/credit-note-res
  * Validates a credit note response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateCreditNoteResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(CreditNoteResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/invoice-response-validator.spec.ts
+++ b/validators/invoice-response-validator.spec.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import { validateInvoiceResponseDto } from './invoice-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const ISSUED = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  invoiceUrl: 'https://invoices.example.com/doc-1.pdf',
+  invoiceNumber: 'INV-2026-0001',
+  invoiceId: 'ext-abc-123',
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateInvoiceResponseDto(body)).map((e) => e.property);
+
+describe('validateInvoiceResponseDto', () => {
+  it('accepts an issued document', async () => {
+    expect(await messages(ISSUED)).toEqual([]);
+  });
+
+  it.each([ResponseStatusEnum.FAILURE, ResponseStatusEnum.PENDING])(
+    'accepts a %s report without any document fields — there is no document to describe',
+    async (status) => {
+      expect(
+        await messages({
+          code: 200,
+          message: 'not issued',
+          status,
+          outboxId: ISSUED.outboxId,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it('rejects a success without the document fields', async () => {
+    const body = omit(ISSUED, 'invoiceUrl', 'invoiceNumber', 'invoiceId');
+    expect((await messages(body)).sort()).toEqual([
+      'invoiceId',
+      'invoiceNumber',
+      'invoiceUrl',
+    ]);
+  });
+
+  it('rejects a report without status or outboxId — nothing to settle or correlate on', async () => {
+    const body = omit(ISSUED, 'status', 'outboxId', '');
+    expect((await messages(body)).sort()).toEqual(['outboxId', 'status']);
+  });
+
+  it('rejects a status outside the enum and a document url that is not a url', async () => {
+    expect((await messages({ ...ISSUED, status: 'done' })).sort()).toEqual([
+      'status',
+    ]);
+    expect(await messages({ ...ISSUED, invoiceUrl: 'not a url' })).toEqual([
+      'invoiceUrl',
+    ]);
+  });
+});

--- a/validators/invoice-response-validator.ts
+++ b/validators/invoice-response-validator.ts
@@ -6,8 +6,8 @@ import { InvoiceResponseDto } from '../dtos/invoice/responses/invoice-response.d
  * Validates an invoice response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateInvoiceResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(InvoiceResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-create-response-validator.spec.ts
+++ b/validators/product-create-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductCreateResponseDto } from './product-create-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductCreateResponseDto(body)).map((e) => e.property);
+
+describe('validateProductCreateResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-create-response-validator.ts
+++ b/validators/product-create-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductCreateResponseDto } from '../dtos/product/responses/product-crea
  * Validates a product create response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductCreateResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductCreateResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-delete-response-validator.spec.ts
+++ b/validators/product-delete-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductDeleteResponseDto } from './product-delete-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductDeleteResponseDto(body)).map((e) => e.property);
+
+describe('validateProductDeleteResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-delete-response-validator.ts
+++ b/validators/product-delete-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductDeleteResponseDto } from '../dtos/product/responses/product-dele
  * Validates a product delete response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductDeleteResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductDeleteResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-downgrade-response-validator.spec.ts
+++ b/validators/product-downgrade-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductDowngradeResponseDto } from './product-downgrade-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductDowngradeResponseDto(body)).map((e) => e.property);
+
+describe('validateProductDowngradeResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-downgrade-response-validator.ts
+++ b/validators/product-downgrade-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductDowngradeResponseDto } from '../dtos/product/responses/product-d
  * Validates a product downgrade response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductDowngradeResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductDowngradeResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-renew-response-validator.spec.ts
+++ b/validators/product-renew-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductRenewResponseDto } from './product-renew-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductRenewResponseDto(body)).map((e) => e.property);
+
+describe('validateProductRenewResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-renew-response-validator.ts
+++ b/validators/product-renew-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductRenewResponseDto } from '../dtos/product/responses/product-renew
  * Validates a product renew response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductRenewResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductRenewResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-suspend-response-validator.spec.ts
+++ b/validators/product-suspend-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductSuspendResponseDto } from './product-suspend-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductSuspendResponseDto(body)).map((e) => e.property);
+
+describe('validateProductSuspendResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-suspend-response-validator.ts
+++ b/validators/product-suspend-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductSuspendResponseDto } from '../dtos/product/responses/product-sus
  * Validates a product suspend response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductSuspendResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductSuspendResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-unsuspend-response-validator.spec.ts
+++ b/validators/product-unsuspend-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductUnsuspendResponseDto } from './product-unsuspend-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductUnsuspendResponseDto(body)).map((e) => e.property);
+
+describe('validateProductUnsuspendResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-unsuspend-response-validator.ts
+++ b/validators/product-unsuspend-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductUnsuspendResponseDto } from '../dtos/product/responses/product-u
  * Validates a product unsuspend response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductUnsuspendResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductUnsuspendResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/product-upgrade-response-validator.spec.ts
+++ b/validators/product-upgrade-response-validator.spec.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { validateProductUpgradeResponseDto } from './product-upgrade-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const VALID = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  itemId: 'item-123',
+  data: { ip: '1.2.3.4' },
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProductUpgradeResponseDto(body)).map((e) => e.property);
+
+describe('validateProductUpgradeResponseDto', () => {
+  it('accepts a full success report', async () => {
+    expect(await messages(VALID)).toEqual([]);
+  });
+
+  it('accepts a report without the optional itemId and data', async () => {
+    const minimal = omit(VALID, 'itemId', 'data', '');
+    expect(await messages(minimal)).toEqual([]);
+  });
+
+  it('rejects a report without status — nothing to settle on', async () => {
+    const body = omit(VALID, 'status', '');
+    expect(await messages(body)).toEqual(['status']);
+  });
+
+  it('rejects a report without outboxId — nothing to correlate on', async () => {
+    const body = omit(VALID, 'outboxId', '');
+    expect(await messages(body)).toEqual(['outboxId']);
+  });
+
+  it('rejects a status outside the enum, a non-string outboxId and item id, and non-object data', async () => {
+    const errors = await messages({
+      ...VALID,
+      status: 123,
+      outboxId: null,
+      itemId: {},
+      data: 'text',
+    });
+    expect(errors.sort()).toEqual(['data', 'itemId', 'outboxId', 'status']);
+  });
+
+  it('still requires the base response fields', async () => {
+    const body = omit(VALID, 'code', 'message', '');
+    expect((await messages(body)).sort()).toEqual(['code', 'message']);
+  });
+});

--- a/validators/product-upgrade-response-validator.ts
+++ b/validators/product-upgrade-response-validator.ts
@@ -6,8 +6,8 @@ import { ProductUpgradeResponseDto } from '../dtos/product/responses/product-upg
  * Validates a product upgrade response object.
  *
  * The core needs this for the deferred hook: that hook's request body IS this
- * response DTO, and a NestJS ValidationPipe cannot validate it (the fields carry
- * only `@JSONSchema`). Issue #27.
+ * response DTO. Nothing is skipped: `status` and `outboxId` are what let the core settle and
+ * correlate the report, so a report without them is unusable. Issue #27.
  *
  * @param {Record<string, unknown>} plainObject - The plain object to validate.
  * @returns {Promise<ValidationError[]>} - A promise that resolves with an array of validation errors.
@@ -16,5 +16,5 @@ export const validateProductUpgradeResponseDto = async (
   plainObject: Record<string, unknown>,
 ): Promise<ValidationError[]> => {
   const response = plainToInstance(ProductUpgradeResponseDto, plainObject);
-  return await validate(response, { skipMissingProperties: true });
+  return await validate(response);
 };

--- a/validators/proforma-invoice-response-validator.spec.ts
+++ b/validators/proforma-invoice-response-validator.spec.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import { validateProformaInvoiceResponseDto } from './proforma-invoice-response-validator';
+import { ResponseStatusEnum } from '../enums/response-status.enum';
+
+const ISSUED = {
+  code: 200,
+  message: 'ok',
+  status: ResponseStatusEnum.SUCCESS,
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  invoiceUrl: 'https://invoices.example.com/doc-1.pdf',
+  invoiceNumber: 'INV-2026-0001',
+  invoiceId: 'ext-abc-123',
+};
+
+const omit = (
+  body: Record<string, unknown>,
+  ...keys: string[]
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(body).filter(([key]) => !keys.includes(key)),
+  );
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProformaInvoiceResponseDto(body)).map((e) => e.property);
+
+describe('validateProformaInvoiceResponseDto', () => {
+  it('accepts an issued document', async () => {
+    expect(await messages(ISSUED)).toEqual([]);
+  });
+
+  it.each([ResponseStatusEnum.FAILURE, ResponseStatusEnum.PENDING])(
+    'accepts a %s report without any document fields — there is no document to describe',
+    async (status) => {
+      expect(
+        await messages({
+          code: 200,
+          message: 'not issued',
+          status,
+          outboxId: ISSUED.outboxId,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it('rejects a success without the document fields', async () => {
+    const body = omit(ISSUED, 'invoiceUrl', 'invoiceNumber', 'invoiceId');
+    expect((await messages(body)).sort()).toEqual([
+      'invoiceId',
+      'invoiceNumber',
+      'invoiceUrl',
+    ]);
+  });
+
+  it('rejects a report without status or outboxId — nothing to settle or correlate on', async () => {
+    const body = omit(ISSUED, 'status', 'outboxId', '');
+    expect((await messages(body)).sort()).toEqual(['outboxId', 'status']);
+  });
+
+  it('rejects a status outside the enum and a document url that is not a url', async () => {
+    expect((await messages({ ...ISSUED, status: 'done' })).sort()).toEqual([
+      'status',
+    ]);
+    expect(await messages({ ...ISSUED, invoiceUrl: 'not a url' })).toEqual([
+      'invoiceUrl',
+    ]);
+  });
+});

--- a/validators/proxy-action-task-validator.spec.ts
+++ b/validators/proxy-action-task-validator.spec.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+import { validateProxyActionTaskDto } from './proxy-action-task-validator';
+
+const TASK = {
+  outboxId: '66d0a1b2c3d4e5f6a7b8c9d0',
+  integrationUrl: 'https://provider.example.com/item/create',
+  integrationToken: 'eyJhbGciOiJIUzI1NiJ9.e30.abc',
+  hookUrl: 'http://localhost:3000/actions/hooks/internal/create',
+  deadLetterQueue: 'outbox-actions-dead-letter',
+  payload: { itemData: { itemId: '66d0a1b2c3d4e5f6a7b8c9d1' } },
+};
+
+const messages = async (body: Record<string, unknown>): Promise<string[]> =>
+  (await validateProxyActionTaskDto(body)).map((e) => e.property);
+
+describe('validateProxyActionTaskDto', () => {
+  it('accepts a complete task', async () => {
+    expect(await messages(TASK)).toEqual([]);
+  });
+
+  it('rejects a task missing any field — the proxy holds no state to fill the gap', async () => {
+    for (const field of Object.keys(TASK)) {
+      const body = Object.fromEntries(
+        Object.entries(TASK).filter(([key]) => key !== field),
+      );
+      expect(await messages(body)).toEqual([field]);
+    }
+  });
+
+  it('rejects urls that are not absolute, a malformed outboxId and a non-object payload', async () => {
+    const errors = await messages({
+      ...TASK,
+      outboxId: 'not-an-object-id',
+      integrationUrl: 'provider.example.com/item/create',
+      hookUrl: 'javascript:alert(1)',
+      payload: 'text',
+    });
+    expect(errors.sort()).toEqual([
+      'hookUrl',
+      'integrationUrl',
+      'outboxId',
+      'payload',
+    ]);
+  });
+});


### PR DESCRIPTION
## Τι αλλάζει

Follow-up του #28, από το review του: οι validators των απαντώσεων (product και invoice) δέχονταν ελλιπείς ή λάθος αναφορές — ένα σώμα με `status: 123` και `outboxId: null` περνούσε καθαρό — γιατί τα product response DTO είχαν μόνο `@JSONSchema` και όλοι οι validators παρέλειπαν τα πεδία που έλειπαν. Αυτό είναι το όριο εμπιστοσύνης του deferred hook στο api.

Σχετικό: #27

## Αλλαγές

- **9 product response DTO**: `status` στο enum, `outboxId` υποχρεωτικό string, `itemId` προαιρετικό string (είναι το id του integration, ο core συσχετίζει μόνο με `outboxId`), `data` προαιρετικό object.
- **Invoice responses**: `status` και `outboxId` πάντα υποχρεωτικά· `invoiceUrl`, `invoiceNumber`, `invoiceId` μόνο σε SUCCESS (`@ValidateIf`) — μια αποτυχία ή ένα pending δεν έχει έγγραφο να περιγράψει.
- **Validators**: κανένας validator απάντησης δεν κάνει πια `skipMissingProperties`.
- **`ProxyActionTaskDto`**: τα URLs απαιτούν πρωτόκολλο· εγγραφή στον schema generator και αναγέννηση του `components.schemas.ts`.
- **Spec ανά validator** (11 νέα αρχεία): valid, missing, invalid.
- **llm mirrors + llm.txt** για το νέο DTO, το enum, τους 11 validators, και ανανέωση των stale mirrors (τα product responses χωρίς `outboxId`, το `ProformaInvoiceResponseDto` χωρίς `BaseResponse`/`status`/`outboxId`, το `BaseInvoiceRequestDto` χωρίς `invoiceId`).

## Tests

- [x] `npm run build`, `npm run build:schemas` καθαρά
- [x] `npx jest validators`: 73 suites, 514 tests, καμία αποτυχία
- [x] Στο api (hoster-ai/api#745, με το ξαναχτισμένο dist): actions e2e 110 πράσινα — τα hooks δεν σπάνε από τους αυστηρότερους validators

## Πριν το merge — checklist

1. [ ] Merge πριν το release `0.0.40`, ώστε τα api PR να πάρουν σωστούς validators με την πρώτη έκδοση.
2. [ ] Τα action request/response DTO (product και invoice) δεν είναι στο `ComponentsSchemas` — δεν ήταν ποτέ. Εγγράφηκε μόνο το `ProxyActionTaskDto`. Αν θέλουμε και τα υπόλοιπα στο integrations Swagger, είναι δική τους απόφαση, όχι αυτού του PR.
